### PR TITLE
add clear interval when using multiple inits

### DIFF
--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -60,6 +60,9 @@ export default class MemoryStore implements Store {
 		// Initialise the hit counter map.
 		this.hits = {}
 
+		// Make sure to reset the previous interval if one was present
+		if (this.interval) this.shutdown()
+
 		// Reset hit counts for ALL clients every `windowMs` - this will also
 		// re-calculate the `resetTime`
 		this.interval = setInterval(async () => {

--- a/test/library/memory-store-test.ts
+++ b/test/library/memory-store-test.ts
@@ -132,4 +132,16 @@ describe('memory store test', () => {
 			clearTimeout(realTimeoutId)
 		}
 	})
+
+	it('When calling init it should reset interval when already initialized', async () => {
+		const shutdownSpy = jest.spyOn(MemoryStore.prototype, 'shutdown')
+
+		const store = new MemoryStore()
+
+		store.init({} as Options)
+		expect(shutdownSpy).toHaveBeenCalledTimes(0)
+
+		store.init({} as Options)
+		expect(shutdownSpy).toHaveBeenCalledTimes(1)
+	})
 })


### PR DESCRIPTION
<!--
	Hi there! Thanks for contributing! Please fill in this template to help us
	review and merge the PR as quickly and easily as possible!
-->

## Related Issues
Fixes https://github.com/nfriedly/express-rate-limit/issues/326

## What Does This PR Do?

### Changed
Added check to memory store that when initialized multiple times, the previous interval is properly cleared. 

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
