### PR TITLE
Revert typescript to 4.x and dts-bundle-generator to 7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@types/supertest": "2.0.12",
 				"cross-env": "7.0.3",
 				"del-cli": "5.0.0",
-				"dts-bundle-generator": "8.0.1",
+				"dts-bundle-generator": "7.2.0",
 				"esbuild": "0.18.11",
 				"express": "4.18.2",
 				"husky": "8.0.3",
@@ -3439,12 +3439,12 @@
 			}
 		},
 		"node_modules/dts-bundle-generator": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-8.0.1.tgz",
-			"integrity": "sha512-9JVw78/OXdKfq+RUrmpLm6WAUJp+aOUGEHimVqIlOEH2VugRt1I8CVIoQZlirWZko+/SVZkNgpWCyZubUuzzPA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.2.0.tgz",
+			"integrity": "sha512-pHjRo52hvvLDRijzIYRTS9eJR7vAOs3gd/7jx+7YVnLU8ay3yPUWGtHXPtuMBSlJYk/s4nq1SvXObDCZVguYMg==",
 			"dev": true,
 			"dependencies": {
-				"typescript": ">=5.0.2",
+				"typescript": ">=4.5.2",
 				"yargs": "^17.6.0"
 			},
 			"bin": {
@@ -14336,12 +14336,12 @@
 			}
 		},
 		"dts-bundle-generator": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-8.0.1.tgz",
-			"integrity": "sha512-9JVw78/OXdKfq+RUrmpLm6WAUJp+aOUGEHimVqIlOEH2VugRt1I8CVIoQZlirWZko+/SVZkNgpWCyZubUuzzPA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.2.0.tgz",
+			"integrity": "sha512-pHjRo52hvvLDRijzIYRTS9eJR7vAOs3gd/7jx+7YVnLU8ay3yPUWGtHXPtuMBSlJYk/s4nq1SvXObDCZVguYMg==",
 			"dev": true,
 			"requires": {
-				"typescript": ">=5.0.2",
+				"typescript": ">=4.5.2",
 				"yargs": "^17.6.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@types/supertest": "2.0.12",
 				"cross-env": "7.0.3",
 				"del-cli": "5.0.0",
-				"dts-bundle-generator": "7.2.0",
+				"dts-bundle-generator": "7.0.0",
 				"esbuild": "0.18.11",
 				"express": "4.18.2",
 				"husky": "8.0.3",
@@ -26,7 +26,7 @@
 				"supertest": "6.3.3",
 				"ts-jest": "29.1.1",
 				"ts-node": "10.9.1",
-				"typescript": "5.1.6",
+				"typescript": "4.9.5",
 				"xo": "0.54.2"
 			},
 			"engines": {
@@ -3439,9 +3439,9 @@
 			}
 		},
 		"node_modules/dts-bundle-generator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.2.0.tgz",
-			"integrity": "sha512-pHjRo52hvvLDRijzIYRTS9eJR7vAOs3gd/7jx+7YVnLU8ay3yPUWGtHXPtuMBSlJYk/s4nq1SvXObDCZVguYMg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.0.0.tgz",
+			"integrity": "sha512-3mhkUvUsxYT5aK4NOJH9iCOMy04vLEeH2gemBD+rSAYn5x7OiLbzyAEzf6gix3jyx/0I9qjYJOja1pvnqBhKDQ==",
 			"dev": true,
 			"dependencies": {
 				"typescript": ">=4.5.2",
@@ -10177,16 +10177,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -11643,6 +11643,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xo/node_modules/typescript": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"dev": true,
+			"inBundle": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/xo/node_modules/yallist": {
@@ -14336,9 +14350,9 @@
 			}
 		},
 		"dts-bundle-generator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.2.0.tgz",
-			"integrity": "sha512-pHjRo52hvvLDRijzIYRTS9eJR7vAOs3gd/7jx+7YVnLU8ay3yPUWGtHXPtuMBSlJYk/s4nq1SvXObDCZVguYMg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.0.0.tgz",
+			"integrity": "sha512-3mhkUvUsxYT5aK4NOJH9iCOMy04vLEeH2gemBD+rSAYn5x7OiLbzyAEzf6gix3jyx/0I9qjYJOja1pvnqBhKDQ==",
 			"dev": true,
 			"requires": {
 				"typescript": ">=4.5.2",
@@ -19208,9 +19222,9 @@
 			}
 		},
 		"typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -20147,6 +20161,13 @@
 					"version": "3.6.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.1.tgz",
 					"integrity": "sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==",
+					"dev": true
+				},
+				"typescript": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+					"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+					"bundled": true,
 					"dev": true
 				},
 				"yallist": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"@types/supertest": "2.0.12",
 		"cross-env": "7.0.3",
 		"del-cli": "5.0.0",
-		"dts-bundle-generator": "7.2.0",
+		"dts-bundle-generator": "7.0.0",
 		"esbuild": "0.18.11",
 		"express": "4.18.2",
 		"husky": "8.0.3",
@@ -93,7 +93,7 @@
 		"supertest": "6.3.3",
 		"ts-jest": "29.1.1",
 		"ts-node": "10.9.1",
-		"typescript": "5.1.6",
+		"typescript": "4.9.5",
 		"xo": "0.54.2"
 	},
 	"xo": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"@types/supertest": "2.0.12",
 		"cross-env": "7.0.3",
 		"del-cli": "5.0.0",
-		"dts-bundle-generator": "8.0.1",
+		"dts-bundle-generator": "7.2.0",
 		"esbuild": "0.18.11",
 		"express": "4.18.2",
 		"husky": "8.0.3",


### PR DESCRIPTION
This is a potential fix for #360 and might be a good idea regardless, as dts-bundle-gen v8.0.0 appears to have [dropped support for typescript <5](https://github.com/timocov/dts-bundle-generator/pull/240). (I should have scrutinized this more closely before including it in a point release...)

Additionally, the types it generates vary slightly depending on which version of typescript is used, so I rolled that back to 4.x as well.

express-rate-limit@6.7.0 used
* typescript@4.8.4
* dts-bundle-generator@7.0.0

express-rate-limit@6.7.1 used
* typescript@5.1.6
* dts-bundle-generator@8.0.1

This PR has 
* typescript@4.9.5
* dts-bundle-generator@7.2.0. 
 
If that doesn't solve the issue, I may revert all the way back to the exact versions used for 6.7.0.
