### PR TITLE
feat: validation check for double-counting hits for a single request

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -307,6 +307,8 @@ const rateLimit = (
 			// Increment the client's hit counter by one
 			const { totalHits, resetTime } = await config.store.increment(key)
 
+			config.validations.singleCount(request, config.store, key)
+
 			// Get the quota (max number of hits) for each client
 			const retrieveQuota =
 				typeof config.max === 'function'

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -47,6 +47,12 @@ export default class MemoryStore implements Store {
 	interval?: NodeJS.Timer
 
 	/**
+	 * Keys incremented in once instance of MemoryStore do not affect other instances
+	 * (This flag prevents false-positives when detecting double-counting.)
+	 */
+	localKeys = true
+
+	/**
 	 * Method that initializes the store.
 	 *
 	 * @param options {Options} - The options used to setup the middleware.

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -47,8 +47,8 @@ export default class MemoryStore implements Store {
 	interval?: NodeJS.Timer
 
 	/**
-	 * Keys incremented in once instance of MemoryStore do not affect other instances
-	 * (This flag prevents false-positives when detecting double-counting.)
+	 * Confirmation that the keys incremented in once instance of MemoryStore
+	 * cannot affect other instances.
 	 */
 	localKeys = true
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -162,6 +162,13 @@ export type Store = {
 	 * Method to shutdown the store, stop timers, and release all resources.
 	 */
 	shutdown?: () => Promise<void> | void
+
+	/**
+	 * Flag to indicate that keys incremented in one instance of this store do not affect other instances.
+	 * Typically false if a database is used, true for MemoryStore.
+	 * Used to help detect double-counting misconfigurations.
+	 **/
+	localKeys?: boolean
 }
 
 /**

--- a/source/types.ts
+++ b/source/types.ts
@@ -164,10 +164,12 @@ export type Store = {
 	shutdown?: () => Promise<void> | void
 
 	/**
-	 * Flag to indicate that keys incremented in one instance of this store do not affect other instances.
-	 * Typically false if a database is used, true for MemoryStore.
+	 * Flag to indicate that keys incremented in one instance of this store can
+	 * not affect other instances. Typically false if a database is used, true for
+	 * MemoryStore.
+	 *
 	 * Used to help detect double-counting misconfigurations.
-	 **/
+	 */
 	localKeys?: boolean
 }
 

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -3,6 +3,7 @@
 
 import { isIP } from 'node:net'
 import type { Request } from 'express'
+import type { Store } from './types'
 
 /**
  * An error thrown/returned when a validation error occurs.
@@ -34,6 +35,20 @@ class ValidationError extends Error {
  * The validations that can be run, as well as the methods to run them.
  */
 export class Validations {
+	/**
+	 * Map of request -> store -> keys
+	 *
+	 * Store is either:
+	 *  - an instance for stores like the MemoryStore where two instances do not share state
+	 *  - a string (usually class name) for stores where multiple instances typically share state, such as the redis store
+	 *
+	 * todo: add a reset method (for tests)
+	 */
+	private static readonly singleCountKeys = new WeakMap<
+		Request,
+		Map<Store | string, string[]>
+	>()
+
 	// eslint-disable-next-line @typescript-eslint/parameter-properties
 	enabled: boolean
 
@@ -118,6 +133,37 @@ export class Validations {
 					`The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users.`,
 				)
 			}
+		})
+	}
+
+	/**
+	 * Ensures a given key is incremented only once per request
+	 * @param req
+	 * @param key
+	 */
+	singleCount(request: Request, store: Store, key: string) {
+		this.wrap(() => {
+			let stores = Validations.singleCountKeys.get(request)
+			if (!stores) {
+				stores = new Map()
+				Validations.singleCountKeys.set(request, stores)
+			}
+
+			const storeKey = store.localKeys ? store : store.constructor.name
+			let keys = stores.get(storeKey)
+			if (!keys) {
+				keys = []
+				stores.set(storeKey, keys)
+			}
+
+			if (keys.includes(key)) {
+				throw new ValidationError(
+					'ERR_ERL_DOUBLE_COUNT',
+					`The hit count for ${key} was incremented more than once for a single request.`,
+				)
+			}
+
+			keys.push(key)
 		})
 	}
 

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -36,11 +36,14 @@ class ValidationError extends Error {
  */
 export class Validations {
 	/**
-	 * Map of request -> store -> keys
+	 * Maps the key used in a store for a certain request, and ensures that the
+	 * same key isn't used more than once per request.
 	 *
-	 * Store is either:
-	 *  - an instance for stores like the MemoryStore where two instances do not share state
-	 *  - a string (usually class name) for stores where multiple instances typically share state, such as the redis store
+	 * The store can be any one of the following:
+	 *  - an instance for stores like the MemoryStore where two instances do not
+	 *    share state.
+	 *  - a string (usually class name) for stores where multiple instances
+	 *    typically share state, such as the redis store.
 	 *
 	 * todo: add a reset method (for tests)
 	 */
@@ -137,23 +140,27 @@ export class Validations {
 	}
 
 	/**
-	 * Ensures a given key is incremented only once per request
-	 * @param req
-	 * @param key
+	 * Ensures a given key is incremented only once per request.
+	 *
+	 * @param request {Request} - The Express request object.
+	 * @param store {Store} - The store class.
+	 * @param key {string} - The key used to store the client's hit count.
+	 *
+	 * @returns {void}
 	 */
 	singleCount(request: Request, store: Store, key: string) {
 		this.wrap(() => {
-			let stores = Validations.singleCountKeys.get(request)
-			if (!stores) {
-				stores = new Map()
-				Validations.singleCountKeys.set(request, stores)
+			let storeKeys = Validations.singleCountKeys.get(request)
+			if (!storeKeys) {
+				storeKeys = new Map()
+				Validations.singleCountKeys.set(request, storeKeys)
 			}
 
 			const storeKey = store.localKeys ? store : store.constructor.name
-			let keys = stores.get(storeKey)
+			let keys = storeKeys.get(storeKey)
 			if (!keys) {
 				keys = []
-				stores.set(storeKey, keys)
+				storeKeys.set(storeKey, keys)
 			}
 
 			if (keys.includes(key)) {

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -40,12 +40,10 @@ export class Validations {
 	 * same key isn't used more than once per request.
 	 *
 	 * The store can be any one of the following:
-	 *  - an instance for stores like the MemoryStore where two instances do not
+	 *  - An instance, for stores like the MemoryStore where two instances do not
 	 *    share state.
-	 *  - a string (usually class name) for stores where multiple instances
-	 *    typically share state, such as the redis store.
-	 *
-	 * todo: add a reset method (for tests)
+	 *  - A string (class name), for stores where multiple instances
+	 *    typically share state, such as the Redis store.
 	 */
 	private static readonly singleCountKeys = new WeakMap<
 		Request,

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -60,6 +60,7 @@ describe('validations tests', () => {
 			validations.trustProxy({ app: { get: () => true } } as any)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should not log an error on "trust proxy" != true', () => {
 			validations.trustProxy({ app: { get: () => false } } as any)
 			validations.trustProxy({ app: { get: () => '1.2.3.4' } } as any)
@@ -84,6 +85,7 @@ describe('validations tests', () => {
 				headers: {},
 			} as any)
 			expect(console.error).not.toBeCalled()
+
 			validations.xForwardedForHeader({
 				app: { get: () => false },
 				headers: { 'x-forwarded-for': '1.2.3.4' },
@@ -93,49 +95,58 @@ describe('validations tests', () => {
 	})
 
 	describe('singleCount', () => {
-		class ExtStore {} // eslint-disable-line @typescript-eslint/no-extraneous-class
+		class TestExternalStore {} // eslint-disable-line @typescript-eslint/no-extraneous-class
 
 		it('should log an error if a request is double-counted with a MemoryStore', () => {
 			const request = {}
 			const store = { localKeys: true }
 			const key = '1.2.3.4'
+
 			validations.singleCount(request as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request as any, store as Store, key)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should log an error if a request is double-counted with an external store', () => {
 			const request = {}
-			const store = new ExtStore()
+			const store = new TestExternalStore()
 			const key = '1.2.3.4'
+
 			validations.singleCount(request as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request as any, store as Store, key)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should not log an error if a request is double-counted with separate instances of MemoryStore', () => {
 			const request = {}
 			const store1 = { localKeys: true }
 			const store2 = { localKeys: true }
 			const key = '1.2.3.4'
+
 			validations.singleCount(request as any, store1 as Store, key)
 			validations.singleCount(request as any, store2 as Store, key)
 			expect(console.error).not.toBeCalled()
 		})
+
 		it('should log an error if a request is double-counted with separate instances of an external store', () => {
 			const request = {}
-			const store1 = new ExtStore()
-			const store2 = new ExtStore()
+			const store1 = new TestExternalStore()
+			const store2 = new TestExternalStore()
 			const key = '1.2.3.4'
+
 			validations.singleCount(request as any, store1 as Store, key)
 			validations.singleCount(request as any, store2 as Store, key)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should not log an error for multiple requests from the same key', () => {
 			const request1 = {}
 			const request2 = {}
 			const store = { localKeys: true }
 			const key = '1.2.3.4'
+
 			validations.singleCount(request1 as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request2 as any, store as Store, key)


### PR DESCRIPTION
This implements the idea discussed in https://github.com/express-rate-limit/express-rate-limit/discussions/356#discussioncomment-6551246 to check for cases of double-counting a single request.

There's probably some situations that this doesn't account for, but I tried to cover the main ones.

We'll want to update the PreciseMemoryStore and set it to `localKeys = true` after merging this. (Although, I'm not sure that `localKeys` is the name I want to settle on.)

## Related Issues

* https://github.com/express-rate-limit/express-rate-limit/issues/362
* Possibly https://github.com/express-rate-limit/express-rate-limit/issues/354

## What Does This PR Do?

### Added

- New validation check looking for double-couting of requests

## Caveats/Problems/Issues

🤷‍♂️ 

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
