### PR TITLE
fix: include url in `ValidationError`

### DIFF
--- a/source/validations.ts
+++ b/source/validations.ts
@@ -20,14 +20,12 @@ class ValidationError extends Error {
 	 * describing the issue in detail.
 	 */
 	constructor(code: string, message: string) {
-		super(
-			`express-rate-limit: ${code} - ${message} See https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes#${code.toLowerCase()} for more information on this error.`,
-		)
+		const url = `https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes#${code.toLowerCase()}`
+		super(`${message} See ${url} for more information on this error.`)
 
 		// `this.constructor.name` is the class name
 		this.name = this.constructor.name
 		this.code = code
-		this.message = message
 	}
 }
 

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -21,7 +21,7 @@ class ValidationError extends Error {
 	 * describing the issue in detail.
 	 */
 	constructor(code: string, message: string) {
-		const url = `https://express-rate-limit.github.io/errors/#${code.toLowerCase()}`
+		const url = `https://express-rate-limit.github.io/${code.toLowerCase()}`
 		super(`${message} See ${url} for more information on this error.`)
 
 		// `this.constructor.name` is the class name

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -11,6 +11,7 @@ import type { Store } from './types'
 class ValidationError extends Error {
 	name: string
 	code: string
+	help: string
 
 	/**
 	 * The code must be a string, in snake case and all capital, that starts with
@@ -26,6 +27,7 @@ class ValidationError extends Error {
 		// `this.constructor.name` is the class name
 		this.name = this.constructor.name
 		this.code = code
+		this.help = url
 	}
 }
 

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -21,7 +21,7 @@ class ValidationError extends Error {
 	 * describing the issue in detail.
 	 */
 	constructor(code: string, message: string) {
-		const url = `https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes#${code.toLowerCase()}`
+		const url = `https://express-rate-limit.github.io/errors/#${code.toLowerCase()}`
 		super(`${message} See ${url} for more information on this error.`)
 
 		// `this.constructor.name` is the class name


### PR DESCRIPTION
I also cleaned up the text a bit since the error code and the fact that it's coming from express-rate-limit are both fairly apparent


## Related Issues

* https://github.com/express-rate-limit/express-rate-limit/issues/363
* https://github.com/express-rate-limit/express-rate-limit/discussions/356#discussioncomment-6551094
* https://github.com/express-rate-limit/express-rate-limit/pull/358

## What Does This PR Do?

### Changes
This fixes the mistake that caused the help URL to be removed from ValidationError messages. 
Additionally, it adds help a property on the object with the URL, for cases like #363 where the text isn't wrapped around.

I also tweaked the wording to remove redundant info and get to the point more quickly (although this redundant info was never actually shown because of the aforementioned mistake).

Previously errors looked like this:
<img width="704" alt="Screenshot 2023-08-03 at 3 25 41 PM" src="https://github.com/express-rate-limit/express-rate-limit/assets/114976/0ad52a61-0fc6-40f2-9e2d-eb67e177db81">

Now they look like this
<img width="801" alt="Screenshot 2023-08-03 at 4 09 53 PM" src="https://github.com/express-rate-limit/express-rate-limit/assets/114976/3987fd56-688b-45ad-a847-23c4f8680280">

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All library tests (`npm run test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
