### PR TITLE
doc: add use-cases section to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ authentication and more to any API in minutes. Learn more at
 [![npm version](https://img.shields.io/npm/v/express-rate-limit.svg)](https://npmjs.org/package/express-rate-limit 'View this project on NPM')
 [![npm downloads](https://img.shields.io/npm/dm/express-rate-limit)](https://www.npmjs.com/package/express-rate-limit)
 
-Basic rate-limiting middleware for Express. Use to limit repeated requests to
+Basic rate-limiting middleware for [Express](http://expressjs.com/). Use to limit repeated requests to
 public APIs and/or endpoints such as password reset. Plays nice with
 [express-slow-down](https://www.npmjs.com/package/express-slow-down).
 

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,7 @@ const limiter = rateLimit({
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+	store: new ExternalStore(), // Use an external store for more precise rate limiting
 })
 
 // Apply the rate limiting middleware to all requests
@@ -136,6 +137,7 @@ const apiLimiter = rateLimit({
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+	store: new ExternalStore(), // Use an external store for more precise rate limiting
 })
 
 // Apply the rate limiting middleware to API calls only
@@ -152,6 +154,7 @@ const apiLimiter = rateLimit({
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+	store: new ExternalStore(), // Use an external store for more precise rate limiting
 })
 
 app.use('/api/', apiLimiter)
@@ -175,15 +178,15 @@ To use a custom store:
 ```ts
 import rateLimit, { MemoryStore } from 'express-rate-limit'
 
-const apiLimiter = rateLimit({
+const rateLimiter = rateLimit({
 	windowMs: 15 * 60 * 1000, // 15 minutes
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	store: new MemoryStore(),
 })
 
-// Apply the rate limiting middleware to API calls only
-app.use('/api', apiLimiter)
+// Apply the rate limiting middleware to all requests
+app.use(rateLimiter)
 ```
 
 > **Note:** most stores will require additional configuration, such as custom

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ public APIs and/or endpoints such as password reset. Plays nice with
 Depending on your use case, you may need to switch to a different
 [store](#store).
 
-#### Basic Abuse Prevention
+#### Abuse Prevention
 
 The default `MemoryStore` is probably fine.
 
@@ -35,17 +35,20 @@ The default `MemoryStore` is probably fine.
 
 You likely want to switch to a different [store](#store). As a performance
 optimization, the default `MemoryStore` uses a global time window, so if your
-limit is 10 requests per minute, a single user might be able to get up to 20
-requests in a row if they happen to get the first 10 in right at the end of one
-minute and the next 10 in at the start of the next minute. All of the other
-stores use per-user time windows, so a user will get exactly 10 requests
+limit is 10 requests per minute, a single user might be able to get an initial
+burst of up to 20 requests in a row if they happen to get the first 10 in at the
+end of one minute and the next 10 in at the start of the next minute. (After the
+initial burst, they will be limited to the expected 10 requests per minute.) All
+other stores use per-user time windows, so a user will get exactly 10 requests
 regardless.
 
-Additionally, if you have multiple servers, or even just multiple processes (for
-example, with the [cluster](https://nodejs.org/api/cluster.html), you'll likely
-want to use an external database to syhcnronize hits, so that a user gets the
-expected result even if some of their requests get handled by different
-servers/processes.
+Additionally, if you have multiple servers or processes (for example, with the
+[node:cluster](https://nodejs.org/api/cluster.html) module), you'll likely want
+to use an external data store to syhcnronize hits
+([redis](https://npmjs.com/package/rate-limit-redis),
+[memcached](https://npmjs.org/package/rate-limit-memcached), [etc.](#store))
+This will guarentee the expected result even if some requests get handled by
+different servers/processes.
 
 ### Alternate Rate Limiters
 

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,9 @@ authentication and more to any API in minutes. Learn more at
 [![npm version](https://img.shields.io/npm/v/express-rate-limit.svg)](https://npmjs.org/package/express-rate-limit 'View this project on NPM')
 [![npm downloads](https://img.shields.io/npm/dm/express-rate-limit)](https://www.npmjs.com/package/express-rate-limit)
 
-Basic rate-limiting middleware for [Express](http://expressjs.com/). Use to limit repeated requests to
-public APIs and/or endpoints such as password reset. Plays nice with
+Basic rate-limiting middleware for [Express](http://expressjs.com/). Use to
+limit repeated requests to public APIs and/or endpoints such as password reset.
+Plays nice with
 [express-slow-down](https://www.npmjs.com/package/express-slow-down).
 
 </div>
@@ -118,7 +119,7 @@ const limiter = rateLimit({
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-	store: new ExternalStore(), // Use an external store for more precise rate limiting
+	// store: ... , // Use an external store for more precise rate limiting
 })
 
 // Apply the rate limiting middleware to all requests
@@ -137,7 +138,7 @@ const apiLimiter = rateLimit({
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-	store: new ExternalStore(), // Use an external store for more precise rate limiting
+	// store: ... , // Use an external store for more precise rate limiting
 })
 
 // Apply the rate limiting middleware to API calls only
@@ -154,7 +155,7 @@ const apiLimiter = rateLimit({
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-	store: new ExternalStore(), // Use an external store for more precise rate limiting
+	// store: ... , // Use an external store for more precise rate limiting
 })
 
 app.use('/api/', apiLimiter)
@@ -176,13 +177,18 @@ app.post('/create-account', createAccountLimiter, (request, response) => {
 To use a custom store:
 
 ```ts
-import rateLimit, { MemoryStore } from 'express-rate-limit'
+import rateLimit from 'express-rate-limit'
+import RedisStore from 'rate-limit-redis'
+import RedisClient from 'ioredis'
 
+const redisClient = new RedisClient()
 const rateLimiter = rateLimit({
 	windowMs: 15 * 60 * 1000, // 15 minutes
 	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-	store: new MemoryStore(),
+	store: new RedisStore({
+		/* ... */
+	}), // Use the external store
 })
 
 // Apply the rate limiting middleware to all requests

--- a/readme.md
+++ b/readme.md
@@ -24,19 +24,30 @@ public APIs and/or endpoints such as password reset. Plays nice with
 
 ## Use Cases
 
-Depending on your use case, you may need to switch to a different [store](#store).
+Depending on your use case, you may need to switch to a different
+[store](#store).
 
-### Basic Abuse Prevention
+#### Basic Abuse Prevention
 
-The default MemoryStore is probably fine. 
+The default `MemoryStore` is probably fine.
 
-### API Rate Limit Enforcement
+#### API Rate Limit Enforcement
 
-You likely want to switch to a different [store](#store). As a performance optimization, the default MemoryStore uses a global time window, so if your limit is 10 requests per minute, a single user might be able to get up to 20 requests in a row if they happen to get the first 10 in right at the end of one minute and the next 10 in at the start of the next minute. All of the other stores use per-user time windows, so a user will get exactly 10 requests regardless.
+You likely want to switch to a different [store](#store). As a performance
+optimization, the default `MemoryStore` uses a global time window, so if your
+limit is 10 requests per minute, a single user might be able to get up to 20
+requests in a row if they happen to get the first 10 in right at the end of one
+minute and the next 10 in at the start of the next minute. All of the other
+stores use per-user time windows, so a user will get exactly 10 requests
+regardless.
 
-Additionally, if you have multiple servers, or even just multiple processes (e.g. with the [cluster](https://nodejs.org/api/cluster.html), you'll likely want to use an external database to syhcnronize hits, so that a user gets the expected result even if some of their requests get handled by different servers/processes.
+Additionally, if you have multiple servers, or even just multiple processes (for
+example, with the [cluster](https://nodejs.org/api/cluster.html), you'll likely
+want to use an external database to syhcnronize hits, so that a user gets the
+expected result even if some of their requests get handled by different
+servers/processes.
 
-#### Alternate Rate Limiters
+### Alternate Rate Limiters
 
 This module was designed to only handle the basics and didn't even support
 external stores initially. These other options all are excellent pieces of

--- a/readme.md
+++ b/readme.md
@@ -22,11 +22,21 @@ public APIs and/or endpoints such as password reset. Plays nice with
 
 </div>
 
-### Alternate Rate Limiters
+## Use Cases
 
-> This module does not share state with other processes/servers by default. If
-> you need a more robust solution, I recommend using an external store. See the
-> [`stores` section](#store) below for a list of external stores.
+Depending on your use case, you may need to switch to a different [store](#store).
+
+### Basic Abuse Prevention
+
+The default MemoryStore is probably fine. 
+
+### API Rate Limit Enforcement
+
+You likely want to switch to a different [store](#store). As a performance optimization, the default MemoryStore uses a global time window, so if your limit is 10 requests per minute, a single user might be able to get up to 20 requests in a row if they happen to get the first 10 in right at the end of one minute and the next 10 in at the start of the next minute. All of the other stores use per-user time windows, so a user will get exactly 10 requests regardless.
+
+Additionally, if you have multiple servers, or even just multiple processes (e.g. with the [cluster](https://nodejs.org/api/cluster.html), you'll likely want to use an external database to syhcnronize hits, so that a user gets the expected result even if some of their requests get handled by different servers/processes.
+
+#### Alternate Rate Limiters
 
 This module was designed to only handle the basics and didn't even support
 external stores initially. These other options all are excellent pieces of


### PR DESCRIPTION
And rework alternate rate limiters section

Should help to address some of the confusion evidenced in https://github.com/express-rate-limit/express-rate-limit/issues/366 and other tickets

Needs formatting because I just did the editing in github's ui