### PR TITLE
feat: draft_polli_ratelimit_headers option deprecation warning

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -171,6 +171,9 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 	// Create the validator before even parsing the rest of the options
 	const validations = new Validations(notUndefinedOptions?.validate ?? true)
 
+	validations.draftPolliRatelimitHeaders(
+		notUndefinedOptions.draft_polli_ratelimit_headers,
+	)
 	validations.onLimitReached(notUndefinedOptions.onLimitReached)
 
 	// See ./types.ts#Options for a detailed description of the options and their

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -198,6 +198,25 @@ export class Validations {
 	}
 
 	/**
+	 * Warns the user that the `draft_polli_ratelimit_headers` option is deprecated and will be removed in the next
+	 * major release.
+	 *
+	 * @param draft_polli_ratelimit_headers {boolean|undefined} - Initial setting to enable standard headers.
+	 *
+	 * @returns {void}
+	 */
+	draftPolliRatelimitHeaders(draft_polli_ratelimit_headers?: boolean) {
+		this.wrap(() => {
+			if (draft_polli_ratelimit_headers) {
+				throw new ChangeWarning(
+					'WRN_ERL_DEPRECATED_DRAFT_POLLI_HEADERS',
+					`The draft_polli_ratelimit_headers configuration option is deprecated and will be removed in express-rate-limit v7, please set standardHeaders: 'draft-6' instead.`,
+				)
+			}
+		})
+	}
+
+	/**
 	 * Warns the user that the `onLimitReached` option is deprecated and will be removed in the next
 	 * major release.
 	 *


### PR DESCRIPTION
## Related Issues

* https://github.com/express-rate-limit/express-rate-limit/discussions/372#discussioncomment-6709956
* https://github.com/express-rate-limit/express-rate-limit/pull/376

## What Does This PR Do?

Logs a warning if the `draft_polli_ratelimit_headers ` is set, directing users to set `standardHeaders: 'draft-6'` instead


## Caveats/Problems/Issues

Still need to set up the redirect and add the warning to the wiki.

Needs a test.

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All library tests (`npm run test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [ ] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
