### PR TITLE
feat!: improve `MemoryStore`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Plays nice with
 
 ## Use Cases
 
-Depending on your use case, you may need to switch to a different
+Depending on your use case, you may want to switch to a different
 [store](#store).
 
 #### Abuse Prevention
@@ -34,22 +34,14 @@ The default `MemoryStore` is probably fine.
 
 #### API Rate Limit Enforcement
 
-You likely want to switch to a different [store](#store). As a performance
-optimization, the default `MemoryStore` uses a global time window, so if your
-limit is 10 requests per minute, a single user might be able to get an initial
-burst of up to 20 requests in a row if they happen to get the first 10 in at the
-end of one minute and the next 10 in at the start of the next minute. (After the
-initial burst, they will be limited to the expected 10 requests per minute.) All
-other stores use per-user time windows, so a user will get exactly 10 requests
-regardless.
-
-Additionally, if you have multiple servers or processes (for example, with the
-[node:cluster](https://nodejs.org/api/cluster.html) module), you'll likely want
-to use an external data store to syhcnronize hits
+You may want to switch to a different [store](#store), especially if you have
+multiple servers or processes (for example, with the
+[node:cluster](https://nodejs.org/api/cluster.html) module). Using an external
+data store to syhcnronize hits
 ([redis](https://npmjs.com/package/rate-limit-redis),
 [memcached](https://npmjs.org/package/rate-limit-memcached), [etc.](#store))
-This will guarentee the expected result even if some requests get handled by
-different servers/processes.
+guarentees the expected result even if some requests get handled by different
+servers/processes or a server is restarted.
 
 ### Alternate Rate Limiters
 

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -188,17 +188,13 @@ export default class MemoryStore implements Store {
 	}
 
 	/**
-	 * Clear out expired clients in previous, then move all current clients to previous.
+	 * Move current clients to previous, create a new map for current.
 	 *
 	 * This function is called every `windowMs`.
 	 */
 	private clearExpired(): void {
-		// At this point, all clients in previous are expired, so delete them all
-		this.previous.clear()
-
-		// Swap previous and current so that current clients are moved to previous and current will have a blank slate
-		const temporary = this.previous
+		// At this point, all clients in previous are expired
 		this.previous = this.current
-		this.current = temporary
+		this.current = new Map()
 	}
 }

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -200,8 +200,9 @@ export default class MemoryStore implements Store {
 
 		let client
 		if (this.previous.has(key)) {
-			// If it's in the `previous` map, return it and bump it up to the `current` map.
+			// If it's in the `previous` map, take it out
 			client = this.previous.get(key)!
+			this.previous.delete(key)
 		} else if (this.pool.length > 0) {
 			// If it's in neither the `current` nor the `previous` maps, animate a corpse
 			// from the pool. Spoooooooooooky!

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -62,8 +62,8 @@ export default class MemoryStore implements Store {
 	/**
 	 * Used to calculate how many entries to keep in the pool.
 	 */
-	numberOfCreatedClients = 0
-	recentClientsCount: number[] = []
+	uncachedCount = 0
+	uncachedCounts: number[] = []
 
 	/**
 	 * A reference to the active timer.
@@ -210,14 +210,14 @@ export default class MemoryStore implements Store {
 			this.resetClient(client)
 
 			// Note that we created a new client.
-			this.numberOfCreatedClients++
+			this.uncachedCount++
 		} else {
 			// If the pool does not have spare corpses, pull one from thin air. Boo!
 			client = { totalHits: 0, resetTime: new Date() }
 			this.resetClient(client)
 
 			// Once more, note that we created a new client.
-			this.numberOfCreatedClients++
+			this.uncachedCount++
 		}
 
 		// Make sure the client is bumped into the `current` map, and return it.
@@ -236,10 +236,10 @@ export default class MemoryStore implements Store {
 
 		// Calculate the new `pool`'s size. The new size is basically the average of
 		// the number of clients created per `windowMs` in the last ten windows.
-		this.recentClientsCount.push(this.numberOfCreatedClients)
-		if (this.recentClientsCount.length > 10) this.recentClientsCount.shift()
-		this.numberOfCreatedClients = 0
-		const targetPoolSize = Math.round(average(this.recentClientsCount))
+		this.uncachedCounts.push(this.uncachedCount)
+		if (this.uncachedCounts.length > 10) this.uncachedCounts.shift()
+		this.uncachedCount = 0
+		const targetPoolSize = Math.round(average(this.uncachedCounts))
 
 		// Calculate how many entries to potentially copy to the pool.
 		let poolSpace = targetPoolSize - this.pool.length

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -109,7 +109,7 @@ export default class MemoryStore implements Store {
 		const client = this.getClient(key)
 
 		const now = Date.now()
-		if (client.resetTime.getTime() < now) {
+		if (client.resetTime.getTime() <= now) {
 			this.resetClient(client, now)
 		}
 
@@ -175,7 +175,7 @@ export default class MemoryStore implements Store {
 	private resetPrevious() {
 		const temporary = this.previous
 		this.previous = this.current
-		let poolSpace = this.pool.length - this.poolSize
+		let poolSpace = this.poolSize - this.pool.length
 		for (const client of temporary.values()) {
 			if (poolSpace > 0) {
 				this.pool.push(client)

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -104,7 +104,7 @@ export default class MemoryStore implements Store {
 	async decrement(key: string): Promise<void> {
 		const client = this.getClient(key)
 
-		if (client.totalHits > 1) client.totalHits--
+		if (client.totalHits > 0) client.totalHits--
 	}
 
 	/**

--- a/test/library/memory-store-test.ts
+++ b/test/library/memory-store-test.ts
@@ -5,7 +5,9 @@ import { jest } from '@jest/globals'
 import MemoryStore from '../../source/memory-store.js'
 import type { Options } from '../../source/index.js'
 
-describe('memory store test', () => {
+const minute = 60 * 1000
+
+describe.only('memory store test', () => {
 	beforeEach(() => {
 		jest.useFakeTimers()
 		jest.spyOn(global, 'clearInterval')
@@ -17,7 +19,7 @@ describe('memory store test', () => {
 
 	it('sets the value to 1 on first call to `increment`', async () => {
 		const store = new MemoryStore()
-		store.init({ windowMs: -1 } as Options)
+		store.init({ windowMs: minute } as Options)
 		const key = 'test-store'
 
 		const { totalHits } = await store.increment(key)
@@ -26,7 +28,7 @@ describe('memory store test', () => {
 
 	it('increments the key for the store when `increment` is called', async () => {
 		const store = new MemoryStore()
-		store.init({ windowMs: -1 } as Options)
+		store.init({ windowMs: minute } as Options)
 		const key = 'test-store'
 
 		await store.increment(key)
@@ -37,7 +39,7 @@ describe('memory store test', () => {
 
 	it('decrements the key for the store when `decrement` is called', async () => {
 		const store = new MemoryStore()
-		store.init({ windowMs: -1 } as Options)
+		store.init({ windowMs: minute } as Options)
 		const key = 'test-store'
 
 		await store.increment(key)
@@ -50,7 +52,7 @@ describe('memory store test', () => {
 
 	it('resets the count for a key in the store when `resetKey` is called', async () => {
 		const store = new MemoryStore()
-		store.init({ windowMs: -1 } as Options)
+		store.init({ windowMs: minute } as Options)
 		const key = 'test-store'
 
 		await store.increment(key)
@@ -62,7 +64,7 @@ describe('memory store test', () => {
 
 	it('resets the count for all keys in the store when `resetAll` is called', async () => {
 		const store = new MemoryStore()
-		store.init({ windowMs: -1 } as Options)
+		store.init({ windowMs: minute } as Options)
 		const keyOne = 'test-store-one'
 		const keyTwo = 'test-store-two'
 
@@ -78,7 +80,7 @@ describe('memory store test', () => {
 
 	it('clears the timer when `shutdown` is called', async () => {
 		const store = new MemoryStore()
-		store.init({ windowMs: -1 } as Options)
+		store.init({ windowMs: minute } as Options)
 		expect(store.interval).toBeDefined()
 		store.shutdown()
 		expect(clearInterval).toHaveBeenCalledWith(store.interval)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"include": ["source/"],
 	"exclude": ["node_modules/"],
-	"extends": "@express-rate-limit/tsconfig"
+	"extends": "@express-rate-limit/tsconfig",
+	"compilerOptions": {
+		"target": "ES2020"
+	}
 }


### PR DESCRIPTION
I've been thinking about how to make the MemoryStore have per-user reset times and still only a single global timer (like `precise-memory-rate-limit`), but *not* have to iterate through all known clients to remove expired ones (unlike `precise-memory-rate-limit`).

I came up with the idea for a previous and current set of clients, where we could pull active ones forward from previous to current, and then at the end of the time window, just blow away the previous, move the current to previous, and create a new current set.

I then refined it a bit to perform less allocations (and by extension, need less garbage collection) by merely swapping previous and current, and then moving the leftover clients from the old previous to a client pool. With an appropriately sized pool, it should be able to completely avoid allocations for most requests.

I had to tweak the tests to use a positive number for `windowMs`, but after that they all passed.

I've also been thinking about a 'ClusterMemoryStore' where there would be a MemoryStore instance on the primary process, and then each worker would communicate with it via IPC to increment and decrement keys.  Then you would only need an external data store for multi-server deployments. Probably should go in it's own module, though.