### PR TITLE
feat: validate `totalHits` value returned from store

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -310,6 +310,7 @@ const rateLimit = (
 			const key = await config.keyGenerator(request, response)
 			// Increment the client's hit counter by one, and make sure it's only by one
 			const { totalHits, resetTime } = await config.store.increment(key)
+			config.validations.positiveHits(totalHits)
 			config.validations.singleCount(request, config.store, key)
 
 			// Get the quota (max number of hits) for each client

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -308,8 +308,11 @@ const rateLimit = (
 
 			// Get a unique key for the client
 			const key = await config.keyGenerator(request, response)
-			// Increment the client's hit counter by one, and make sure it's only by one
+			// Increment the client's hit counter by one.
 			const { totalHits, resetTime } = await config.store.increment(key)
+			// Make sure that -
+			// - the hit count is incremented only by one.
+			// - the returned hit count is a positive integer.
 			config.validations.positiveHits(totalHits)
 			config.validations.singleCount(request, config.store, key)
 

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -144,6 +144,22 @@ export class Validations {
 	}
 
 	/**
+	 * Ensures totalHits value from store is a positive integer.
+	 *
+	 * @param hits
+	 */
+	positiveHits(hits: number) {
+		this.wrap(() => {
+			if (typeof hits !== 'number' || hits < 1 || hits !== Math.round(hits)) {
+				throw new ValidationError(
+					'ERR_ERL_INVALID_HITS',
+					`The totalHits value returned from the store must be a positive integer, got ${hits}`,
+				)
+			}
+		})
+	}
+
+	/**
 	 * Ensures a given key is incremented only once per request.
 	 *
 	 * @param request {Request} - The Express request object.

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -146,14 +146,14 @@ export class Validations {
 	/**
 	 * Ensures totalHits value from store is a positive integer.
 	 *
-	 * @param hits
+	 * @param hits {any} - The `totalHits` returned by the store.
 	 */
-	positiveHits(hits: number) {
+	positiveHits(hits: any) {
 		this.wrap(() => {
 			if (typeof hits !== 'number' || hits < 1 || hits !== Math.round(hits)) {
 				throw new ValidationError(
 					'ERR_ERL_INVALID_HITS',
-					`The totalHits value returned from the store must be a positive integer, got ${hits}`,
+					`The totalHits value returned from the store must be a positive integer, got ${hits}`, // eslint-disable-line @typescript-eslint/restrict-template-expressions
 				)
 			}
 		})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -95,6 +95,25 @@ describe('validations tests', () => {
 		})
 	})
 
+	describe('positiveHits', () => {
+		it('should log an error if hits is non-numeric', () => {
+			;(validations.positiveHits as (input: any) => void)(true)
+			expect(console.error).toBeCalled()
+		})
+		it('should log an error if hits is less than 1', () => {
+			validations.positiveHits(0)
+			expect(console.error).toBeCalled()
+		})
+		it('should log an error if hits is not an integer', () => {
+			validations.positiveHits(1.5)
+			expect(console.error).toBeCalled()
+		})
+		it('should not log an error if hits is a positive integer', () => {
+			validations.positiveHits(1)
+			expect(console.error).not.toBeCalled()
+		})
+	})
+
 	describe('singleCount', () => {
 		class TestExternalStore {} // eslint-disable-line @typescript-eslint/no-extraneous-class
 

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -97,17 +97,20 @@ describe('validations tests', () => {
 
 	describe('positiveHits', () => {
 		it('should log an error if hits is non-numeric', () => {
-			;(validations.positiveHits as (input: any) => void)(true)
+			validations.positiveHits(true)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should log an error if hits is less than 1', () => {
 			validations.positiveHits(0)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should log an error if hits is not an integer', () => {
 			validations.positiveHits(1.5)
 			expect(console.error).toBeCalled()
 		})
+
 		it('should not log an error if hits is a positive integer', () => {
 			validations.positiveHits(1)
 			expect(console.error).not.toBeCalled()


### PR DESCRIPTION
Checks that the value is a positive integer. Would have helped with https://github.com/express-rate-limit/express-rate-limit/issues/353

todo:
* [x] write wiki entry
* [x] create redirect
* [x] test manually