### PR TITLE
fix!: `max: 0` should rate limits all requests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,7 +257,11 @@ limiting the client.
 Can be the limit itself as a number or a (sync/async) function that accepts the
 Express `request` and `response` objects and then returns a number.
 
-Defaults to `5`. Set it to `0` to disable the rate limiter.
+~Set it to `0` to disable the rate limiter.~ As of version 7.0.0, setting `max`
+to zero will no longer disable the rate limiter - instead, it will 'block' all
+requests to that endpoint.
+
+Defaults to `5`.
 
 An example of using a function:
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -401,7 +401,7 @@ const rateLimit = (
 			config.validations.disable()
 
 			// If the client has exceeded their rate limit, set the Retry-After header
-			// and call the `handler` function
+			// and call the `handler` function.
 			if (typeof maxHits === 'number' && totalHits > maxHits) {
 				if (config.legacyHeaders || config.standardHeaders) {
 					setRetryAfterHeader(response, info, config.windowMs)

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -401,8 +401,8 @@ const rateLimit = (
 			config.validations.disable()
 
 			// If the client has exceeded their rate limit, set the Retry-After header
-			// and call the `handler` function.
-			if (maxHits && totalHits > maxHits) {
+			// and call the `handler` function
+			if (typeof maxHits === 'number' && totalHits > maxHits) {
 				if (config.legacyHeaders || config.standardHeaders) {
 					setRetryAfterHeader(response, info, config.windowMs)
 				}

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -402,7 +402,7 @@ const rateLimit = (
 
 			// If the client has exceeded their rate limit, set the Retry-After header
 			// and call the `handler` function.
-			if (typeof maxHits === 'number' && totalHits > maxHits) {
+			if (totalHits > maxHits) {
 				if (config.legacyHeaders || config.standardHeaders) {
 					setRetryAfterHeader(response, info, config.windowMs)
 				}

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -192,6 +192,12 @@ describe('middleware test', () => {
 		await request(app).get('/').expect(200)
 	})
 
+	it('should block all requests if max is set to 0', async () => {
+		const app = createServer(rateLimit({ max: 0 }))
+
+		await request(app).get('/').expect(429)
+	})
+
 	it('should show the provided message instead of the default message when max connections are reached', async () => {
 		const message = 'Enhance your calm'
 		const app = createServer(


### PR DESCRIPTION
## Overview

This PR fixes #259. Once this PR is merged, setting the `max` option to zero will 'block' all requests to that endpoint.

---

This is a breaking change, and should be merged as part of v7.