### PR TITLE
chore: drop deprecated options

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -11,7 +11,6 @@ import type {
 	IncrementResponse,
 	ValueDeterminingMiddleware,
 	RateLimitExceededEventHandler,
-	RateLimitReachedEventHandler,
 	DraftHeadersVersion,
 	RateLimitInfo,
 } from './types.js'
@@ -112,7 +111,6 @@ type Configuration = {
 	skipSuccessfulRequests: boolean
 	keyGenerator: ValueDeterminingMiddleware<string>
 	handler: RateLimitExceededEventHandler
-	onLimitReached: RateLimitReachedEventHandler
 	skip: ValueDeterminingMiddleware<boolean>
 	requestWasSuccessful: ValueDeterminingMiddleware<boolean>
 	store: Store
@@ -186,6 +184,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 		// @ts-expect-error see the note above.
 		notUndefinedOptions.draft_polli_ratelimit_headers,
 	)
+	// @ts-expect-error see the note above.
 	validations.onLimitReached(notUndefinedOptions.onLimitReached)
 
 	// The default value for the `standardHeaders` option is `false`. If set to
@@ -240,11 +239,6 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 				response.send(message)
 			}
 		},
-		onLimitReached(
-			_request: Request,
-			_response: Response,
-			_optionsUsed: Options,
-		): void {},
 		// Allow the default options to be overriden by the options passed to the middleware.
 		...notUndefinedOptions,
 		// `standardHeaders` is resolved into a draft version above, use that.
@@ -401,13 +395,6 @@ const rateLimit = (
 							await decrementKey()
 					})
 				}
-			}
-
-			// Call the `onLimitReached` callback on the first request where client
-			// exceeds their rate limit
-			// TODO: `onLimitReached` is deprecated, this should be removed in v7.x
-			if (maxHits && totalHits === maxHits + 1) {
-				config.onLimitReached(request, response, options)
 			}
 
 			// Disable the validations, since they should have run at least once by now.

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -180,24 +180,19 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 	// Create the validator before even parsing the rest of the options.
 	const validations = new Validations(notUndefinedOptions?.validate ?? true)
 
-	// Warn for the deprecated options.
+	// Warn for the deprecated options. Note that these options have been removed
+	// from the type definitions in v7.
 	validations.draftPolliHeaders(
+		// @ts-expect-error see the note above.
 		notUndefinedOptions.draft_polli_ratelimit_headers,
 	)
 	validations.onLimitReached(notUndefinedOptions.onLimitReached)
 
-	// The default value for the `standardHeaders` option is `false`.
-	// If set to `true`, it resolve to `draft-6`.
-	// The deprecated `draft_polli_ratelimit_headers` option also resolves to `draft-6`.
-	// `draft-7` (recommended) is used only if explicitly set.
+	// The default value for the `standardHeaders` option is `false`. If set to
+	// `true`, it resolve to `draft-6`. `draft-7` (recommended) is used only if
+	// explicitly set.
 	let standardHeaders = notUndefinedOptions.standardHeaders ?? false
-	if (
-		standardHeaders === true ||
-		(standardHeaders === undefined &&
-			notUndefinedOptions.draft_polli_ratelimit_headers)
-	) {
-		standardHeaders = 'draft-6'
-	}
+	if (standardHeaders === true) standardHeaders = 'draft-6'
 
 	// See ./types.ts#Options for a detailed description of the options and their
 	// defaults.

--- a/source/types.ts
+++ b/source/types.ts
@@ -310,14 +310,6 @@ export type Options = {
 	 * @deprecated 6.x - This option was renamed to `legacyHeaders`.
 	 */
 	headers?: boolean
-
-	/**
-	 * Whether to send `RateLimit-*` headers with the rate limit and the number
-	 * of requests.
-	 *
-	 * @deprecated 6.x - This option was renamed to `standardHeaders`.
-	 */
-	draft_polli_ratelimit_headers?: boolean
 }
 
 /**

--- a/source/types.ts
+++ b/source/types.ts
@@ -266,15 +266,6 @@ export type Options = {
 	handler: RateLimitExceededEventHandler
 
 	/**
-	 * Express request handler that sends back a response when a client has
-	 * reached their rate limit, and will be rate limited on their next request.
-	 *
-	 * @deprecated 6.x - Please use a custom `handler` that checks the number of
-	 * hits instead.
-	 */
-	onLimitReached: RateLimitReachedEventHandler
-
-	/**
 	 * Method (in the form of middleware) to determine whether or not this request
 	 * counts towards a client's quota.
 	 *

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -217,16 +217,16 @@ export class Validations {
 	 * Warns the user that the `draft_polli_ratelimit_headers` option is deprecated
 	 * and will be removed in the next major release.
 	 *
-	 * @param draft_polli_ratelimit_headers {boolean|undefined} - The now-deprecated setting that was used to enable standard headers.
+	 * @param draft_polli_ratelimit_headers {any | undefined} - The now-deprecated setting that was used to enable standard headers.
 	 *
 	 * @returns {void}
 	 */
-	draftPolliHeaders(draft_polli_ratelimit_headers?: boolean) {
+	draftPolliHeaders(draft_polli_ratelimit_headers?: any) {
 		this.wrap(() => {
 			if (draft_polli_ratelimit_headers) {
 				throw new ChangeWarning(
 					'WRN_ERL_DEPRECATED_DRAFT_POLLI_HEADERS',
-					`The draft_polli_ratelimit_headers configuration option is deprecated and will be removed in express-rate-limit v7, please set standardHeaders: 'draft-6' instead.`,
+					`The draft_polli_ratelimit_headers configuration option is deprecated and has been removed in express-rate-limit v7, please set standardHeaders: 'draft-6' instead.`,
 				)
 			}
 		})

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -3,7 +3,7 @@
 
 import { isIP } from 'node:net'
 import type { Request } from 'express'
-import type { RateLimitReachedEventHandler, Store } from './types'
+import type { Store } from './types'
 
 /**
  * An error thrown/returned when a validation error occurs.
@@ -236,16 +236,16 @@ export class Validations {
 	 * Warns the user that the `onLimitReached` option is deprecated and will be removed in the next
 	 * major release.
 	 *
-	 * @param onLimitReached {function|undefined} - The maximum number of hits per client.
+	 * @param onLimitReached {any | undefined} - The maximum number of hits per client.
 	 *
 	 * @returns {void}
 	 */
-	onLimitReached(onLimitReached?: RateLimitReachedEventHandler) {
+	onLimitReached(onLimitReached?: any) {
 		this.wrap(() => {
 			if (onLimitReached) {
 				throw new ChangeWarning(
 					'WRN_ERL_DEPRECATED_ON_LIMIT_REACHED',
-					`The onLimitReached configuration option is deprecated and will be removed in express-rate-limit v7.`,
+					`The onLimitReached configuration option is deprecated and has been removed in express-rate-limit v7.`,
 				)
 			}
 		})

--- a/test/library/options-test.ts
+++ b/test/library/options-test.ts
@@ -21,35 +21,6 @@ describe('options test', () => {
 		}).toThrowError(/store/)
 	})
 
-	// TODO: Update in v7.
-	it('should allow the use of pre-6.x headers options', async () => {
-		class MockStore implements Store {
-			options!: Options
-
-			init(options: Options): void {
-				this.options = options
-			}
-
-			async increment(_key: string): Promise<IncrementResponse> {
-				return { totalHits: 1, resetTime: undefined }
-			}
-
-			async decrement(_key: string): Promise<void> {}
-
-			async resetKey(_key: string): Promise<void> {}
-		}
-
-		const store = new MockStore()
-		rateLimit({
-			store,
-			headers: false,
-			draft_polli_ratelimit_headers: true, // eslint-disable-line @typescript-eslint/naming-convention
-		})
-
-		expect(store.options.headers).toEqual(false)
-		expect(store.options.draft_polli_ratelimit_headers).toEqual(true)
-	})
-
 	it('should not call `init` if it is not a function', async () => {
 		class InvalidStore implements Store {
 			options!: Options


### PR DESCRIPTION
## Overview

Once this PR is merged, setting the `onLimitReached` and `draft_polli_ratelimit_headers` option will have no effect, apart from triggering a `ChangeWarning` validation error.

---

This is a breaking change, and should be merged as part of v7.