### PR TITLE
build: drop node 14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Test (Library)
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [lts/gallium, lts/*, latest]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: lts/*
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"xo": "0.54.2"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 16"
 			},
 			"peerDependencies": {
 				"express": "^4 || ^5"

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
 		"changelog.md"
 	],
 	"engines": {
-		"node": ">= 14"
+		"node": ">= 16"
 	},
 	"scripts": {
 		"clean": "del-cli dist/ coverage/ *.log *.tmp *.bak *.tgz",
-		"build:cjs": "esbuild --platform=node --bundle --target=es2019 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = rateLimit; module.exports.default = rateLimit; module.exports.rateLimit = rateLimit; module.exports.MemoryStore = MemoryStore;\" source/index.ts",
-		"build:esm": "esbuild --platform=node --bundle --target=es2019 --format=esm --outfile=dist/index.mjs source/index.ts",
+		"build:cjs": "esbuild --platform=node --bundle --target=es2022 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = rateLimit; module.exports.default = rateLimit; module.exports.rateLimit = rateLimit; module.exports.MemoryStore = MemoryStore;\" source/index.ts",
+		"build:esm": "esbuild --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
 		"build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts dist/index.d.mts",
 		"compile": "run-s clean build:*",
 		"lint:code": "xo --ignore test/external/",

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Replace `{version}` with the version of the package that you want to your, e.g.:
 This library is provided in ESM as well as CJS forms, and works with both
 Javascript and Typescript projects.
 
-**This package requires you to use Node 14 or above.**
+**This package requires you to use Node 16 or above.**
 
 Import it in a CommonJS project (`type: commonjs` or no `type` field in
 `package.json`) as follows:


### PR DESCRIPTION
## Overview

This PR excludes node 14 from the CI, and bumps the typescript build target to `es2022`. 

---

This is a breaking change, and should be merged as part of v7.