### PR TITLE
chore: move jest config to standard location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage/
 *.tmp
 *.bak
 *.tgz
+
+test/external/imports/*/*/package-lock.json

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,4 @@
 {
-	"rootDir": "../",
 	"preset": "ts-jest/presets/default-esm",
 	"collectCoverage": true,
 	"collectCoverageFrom": ["source/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "format:code": "xo --fix",
     "format:rest": "prettier --write .",
     "format": "run-s format:*",
-    "test:lib": "cross-env NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules jest --config config/jest.json",
+    "test:lib": "jest",
     "test:ext": "cd test/external/ && bash run-all-tests",
     "test": "run-s lint test:lib",
     "pre-commit": "lint-staged",


### PR DESCRIPTION
Per https://jestjs.io/docs/configuration moving the jest config to `jest.cnfig.json`  allows it to be automatically discovered. This in turn makes the jest plugin for vs code "just work" (presumably other editors too), allowing me to easily run or debug individual tests.

I also cleaned up the command line to execute the tests, because I don't think we need any of those flags any more. 

Finally, I added the various external tests package-lock.json's to the .gitignore because they started showing up for some reason.