### PR TITLE
feat: add `get` method to the `Store` interface

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -8,7 +8,7 @@ import type {
 	RateLimitRequestHandler,
 	LegacyStore,
 	Store,
-	IncrementResponse,
+	ClientRateLimitInfo,
 	ValueDeterminingMiddleware,
 	RateLimitExceededEventHandler,
 	DraftHeadersVersion,
@@ -53,7 +53,7 @@ const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 
 	// A promisified version of the store
 	class PromisifiedStore implements Store {
-		async increment(key: string): Promise<IncrementResponse> {
+		async increment(key: string): Promise<ClientRateLimitInfo> {
 			return new Promise((resolve, reject) => {
 				legacyStore.incr(
 					key,
@@ -75,6 +75,13 @@ const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 
 		async resetKey(key: string): Promise<void> {
 			return legacyStore.resetKey(key)
+		}
+
+		/* istanbul ignore next */
+		async fetchKey(key: string): Promise<ClientRateLimitInfo | undefined> {
+			// TODO: Add a validation check to tell the user that this function should
+			// never be called.
+			return undefined
 		}
 
 		/* istanbul ignore next */
@@ -414,10 +421,12 @@ const rateLimit = (
 		},
 	)
 
-	// Export the store's function to reset the hit counter for a particular
-	// client based on their identifier
+	// Export the store's function to reset and fetch the rate limit info for a
+	// client based on their identifier.
 	;(middleware as RateLimitRequestHandler).resetKey =
 		config.store.resetKey.bind(config.store)
+	;(middleware as RateLimitRequestHandler).fetchKey =
+		config.store.fetchKey.bind(config.store)
 
 	return middleware as RateLimitRequestHandler
 }

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -53,6 +53,13 @@ const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 
 	// A promisified version of the store
 	class PromisifiedStore implements Store {
+		/* istanbul ignore next */
+		async get(key: string): Promise<ClientRateLimitInfo | undefined> {
+			// TODO: Add a validation check to tell the user that this function should
+			// never be called.
+			return undefined
+		}
+
 		async increment(key: string): Promise<ClientRateLimitInfo> {
 			return new Promise((resolve, reject) => {
 				legacyStore.incr(
@@ -75,13 +82,6 @@ const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 
 		async resetKey(key: string): Promise<void> {
 			return legacyStore.resetKey(key)
-		}
-
-		/* istanbul ignore next */
-		async fetchKey(key: string): Promise<ClientRateLimitInfo | undefined> {
-			// TODO: Add a validation check to tell the user that this function should
-			// never be called.
-			return undefined
 		}
 
 		/* istanbul ignore next */
@@ -425,8 +425,9 @@ const rateLimit = (
 	// client based on their identifier.
 	;(middleware as RateLimitRequestHandler).resetKey =
 		config.store.resetKey.bind(config.store)
-	;(middleware as RateLimitRequestHandler).fetchKey =
-		config.store.fetchKey.bind(config.store)
+	;(middleware as RateLimitRequestHandler).getKey = config.store.get?.bind(
+		config.store,
+	)
 
 	return middleware as RateLimitRequestHandler
 }

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -72,6 +72,19 @@ export default class MemoryStore implements Store {
 	}
 
 	/**
+	 * Method to fetch a client's hit count and reset time.
+	 *
+	 * @param key {string} - The identifier for a client.
+	 *
+	 * @returns {ClientRateLimitInfo | undefined} - The number of hits and reset time for that client.
+	 *
+	 * @public
+	 */
+	async get(key: string): Promise<ClientRateLimitInfo | undefined> {
+		return this.current.get(key) ?? this.previous.get(key)
+	}
+
+	/**
 	 * Method to increment a client's hit counter.
 	 *
 	 * @param key {string} - The identifier for a client.
@@ -115,19 +128,6 @@ export default class MemoryStore implements Store {
 	async resetKey(key: string): Promise<void> {
 		this.current.delete(key)
 		this.previous.delete(key)
-	}
-
-	/**
-	 * Method to fetch a client's hit count and reset time.
-	 *
-	 * @param key {string} - The identifier for a client.
-	 *
-	 * @returns {ClientRateLimitInfo | undefined} - The number of hits and reset time for that client.
-	 *
-	 * @public
-	 */
-	async fetchKey(key: string): Promise<ClientRateLimitInfo | undefined> {
-		return this.current.get(key) ?? this.previous.get(key)
 	}
 
 	/**

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -1,13 +1,13 @@
 // /source/memory-store.ts
 // A memory store for hit counts
 
-import type { Store, Options, IncrementResponse } from './types.js'
+import type { Store, Options, ClientRateLimitInfo } from './types.js'
 
 /**
  * The record that stores information about a client - namely, how many times
  * they have hit the endpoint, and when their hit count resets.
  *
- * Similar to `IncrementResponse`, except `resetTime` is a compulsory field.
+ * Similar to `ClientRateLimitInfo`, except `resetTime` is a compulsory field.
  */
 type Client = {
 	totalHits: number
@@ -76,11 +76,11 @@ export default class MemoryStore implements Store {
 	 *
 	 * @param key {string} - The identifier for a client.
 	 *
-	 * @returns {IncrementResponse} - The number of hits and reset time for that client.
+	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client.
 	 *
 	 * @public
 	 */
-	async increment(key: string): Promise<IncrementResponse> {
+	async increment(key: string): Promise<ClientRateLimitInfo> {
 		const client = this.getClient(key)
 
 		const now = Date.now()
@@ -115,6 +115,19 @@ export default class MemoryStore implements Store {
 	async resetKey(key: string): Promise<void> {
 		this.current.delete(key)
 		this.previous.delete(key)
+	}
+
+	/**
+	 * Method to fetch a client's hit count and reset time.
+	 *
+	 * @param key {string} - The identifier for a client.
+	 *
+	 * @returns {ClientRateLimitInfo | undefined} - The number of hits and reset time for that client.
+	 *
+	 * @public
+	 */
+	async fetchKey(key: string): Promise<ClientRateLimitInfo | undefined> {
+		return this.current.get(key) ?? this.previous.get(key)
 	}
 
 	/**

--- a/source/types.ts
+++ b/source/types.ts
@@ -67,7 +67,7 @@ export type RateLimitReachedEventHandler = (
  * @property totalHits {number} - The number of hits for that client so far.
  * @property resetTime {Date | undefined} - The time when the counter resets.
  */
-export type IncrementResponse = {
+export type ClientRateLimitInfo = {
 	totalHits: number
 	resetTime: Date | undefined
 }
@@ -82,6 +82,20 @@ export type RateLimitRequestHandler = RequestHandler & {
 	 * @param key {string} - The identifier for a client.
 	 */
 	resetKey: (key: string) => void
+
+	/**
+	 * Method to fetch a client's hit count and reset time.
+	 *
+	 * @param key {string} - The identifier for a client.
+	 *
+	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client.
+	 */
+	fetchKey: (
+		key: string,
+	) =>
+		| Promise<ClientRateLimitInfo | undefined>
+		| ClientRateLimitInfo
+		| undefined
 }
 
 /**
@@ -135,9 +149,9 @@ export type Store = {
 	 *
 	 * @param key {string} - The identifier for a client.
 	 *
-	 * @returns {IncrementResponse} - The number of hits and reset time for that client.
+	 * @returns {ClientRateLimitInfo | undefined} - The number of hits and reset time for that client.
 	 */
-	increment: (key: string) => Promise<IncrementResponse> | IncrementResponse
+	increment: (key: string) => Promise<ClientRateLimitInfo> | ClientRateLimitInfo
 
 	/**
 	 * Method to decrement a client's hit counter.
@@ -152,6 +166,20 @@ export type Store = {
 	 * @param key {string} - The identifier for a client.
 	 */
 	resetKey: (key: string) => Promise<void> | void
+
+	/**
+	 * Method to fetch a client's hit count and reset time.
+	 *
+	 * @param key {string} - The identifier for a client.
+	 *
+	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client.
+	 */
+	fetchKey: (
+		key: string,
+	) =>
+		| Promise<ClientRateLimitInfo | undefined>
+		| ClientRateLimitInfo
+		| undefined
 
 	/**
 	 * Method to reset everyone's hit counter.

--- a/source/types.ts
+++ b/source/types.ts
@@ -90,7 +90,7 @@ export type RateLimitRequestHandler = RequestHandler & {
 	 *
 	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client.
 	 */
-	fetchKey: (
+	getKey?: (
 		key: string,
 	) =>
 		| Promise<ClientRateLimitInfo | undefined>
@@ -145,6 +145,20 @@ export type Store = {
 	init?: (options: Options) => void
 
 	/**
+	 * Method to fetch a client's hit count and reset time.
+	 *
+	 * @param key {string} - The identifier for a client.
+	 *
+	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client.
+	 */
+	get?: (
+		key: string,
+	) =>
+		| Promise<ClientRateLimitInfo | undefined>
+		| ClientRateLimitInfo
+		| undefined
+
+	/**
 	 * Method to increment a client's hit counter.
 	 *
 	 * @param key {string} - The identifier for a client.
@@ -166,20 +180,6 @@ export type Store = {
 	 * @param key {string} - The identifier for a client.
 	 */
 	resetKey: (key: string) => Promise<void> | void
-
-	/**
-	 * Method to fetch a client's hit count and reset time.
-	 *
-	 * @param key {string} - The identifier for a client.
-	 *
-	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client.
-	 */
-	fetchKey: (
-		key: string,
-	) =>
-		| Promise<ClientRateLimitInfo | undefined>
-		| ClientRateLimitInfo
-		| undefined
 
 	/**
 	 * Method to reset everyone's hit counter.

--- a/test/external/imports/default-import/ts-cjs/source/app.ts
+++ b/test/external/imports/default-import/ts-cjs/source/app.ts
@@ -29,6 +29,13 @@ export class TestStore implements Store {
 		delete this.hits[key]
 	}
 
+	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async shutdown(): Promise<void> {
 		console.log('Shutdown successful')
 	}

--- a/test/external/imports/default-import/ts-cjs/source/app.ts
+++ b/test/external/imports/default-import/ts-cjs/source/app.ts
@@ -11,6 +11,13 @@ import rateLimit, {
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
+	async get(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
@@ -27,13 +34,6 @@ export class TestStore implements Store {
 
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
-	}
-
-	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
-		return {
-			totalHits: this.hits[key],
-			resetTime: undefined,
-		}
 	}
 
 	async shutdown(): Promise<void> {

--- a/test/external/imports/default-import/ts-cjs/source/app.ts
+++ b/test/external/imports/default-import/ts-cjs/source/app.ts
@@ -5,13 +5,13 @@ import createServer from 'express'
 import rateLimit, {
 	MemoryStore,
 	Store,
-	IncrementResponse,
+	ClientRateLimitInfo,
 } from 'express-rate-limit'
 
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
-	async increment(key: string): Promise<IncrementResponse> {
+	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
 

--- a/test/external/imports/default-import/ts-esm/source/app.ts
+++ b/test/external/imports/default-import/ts-esm/source/app.ts
@@ -11,6 +11,13 @@ import rateLimit, {
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
+	async get(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
@@ -23,13 +30,6 @@ export class TestStore implements Store {
 
 	async decrement(key: string): Promise<void> {
 		if (this.hits[key]) this.hits[key]--
-	}
-
-	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
-		return {
-			totalHits: this.hits[key],
-			resetTime: undefined,
-		}
 	}
 
 	async resetKey(key: string): Promise<void> {

--- a/test/external/imports/default-import/ts-esm/source/app.ts
+++ b/test/external/imports/default-import/ts-esm/source/app.ts
@@ -25,6 +25,13 @@ export class TestStore implements Store {
 		if (this.hits[key]) this.hits[key]--
 	}
 
+	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}

--- a/test/external/imports/default-import/ts-esm/source/app.ts
+++ b/test/external/imports/default-import/ts-esm/source/app.ts
@@ -5,13 +5,13 @@ import createServer from 'express'
 import rateLimit, {
 	MemoryStore,
 	Store,
-	IncrementResponse,
+	ClientRateLimitInfo,
 } from 'express-rate-limit'
 
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
-	async increment(key: string): Promise<IncrementResponse> {
+	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
 

--- a/test/external/imports/named-import/ts-cjs/source/app.ts
+++ b/test/external/imports/named-import/ts-cjs/source/app.ts
@@ -26,6 +26,13 @@ export class TestStore implements Store {
 		if (this.hits[key]) this.hits[key]--
 	}
 
+	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}

--- a/test/external/imports/named-import/ts-cjs/source/app.ts
+++ b/test/external/imports/named-import/ts-cjs/source/app.ts
@@ -12,6 +12,13 @@ import {
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
+	async get(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
@@ -24,13 +31,6 @@ export class TestStore implements Store {
 
 	async decrement(key: string): Promise<void> {
 		if (this.hits[key]) this.hits[key]--
-	}
-
-	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
-		return {
-			totalHits: this.hits[key],
-			resetTime: undefined,
-		}
 	}
 
 	async resetKey(key: string): Promise<void> {

--- a/test/external/imports/named-import/ts-cjs/source/app.ts
+++ b/test/external/imports/named-import/ts-cjs/source/app.ts
@@ -6,13 +6,13 @@ import {
 	rateLimit,
 	MemoryStore,
 	Store,
-	IncrementResponse,
+	ClientRateLimitInfo,
 } from 'express-rate-limit'
 
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
-	async increment(key: string): Promise<IncrementResponse> {
+	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
 

--- a/test/external/imports/named-import/ts-esm/source/app.ts
+++ b/test/external/imports/named-import/ts-esm/source/app.ts
@@ -26,6 +26,13 @@ export class TestStore implements Store {
 		if (this.hits[key]) this.hits[key]--
 	}
 
+	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}

--- a/test/external/imports/named-import/ts-esm/source/app.ts
+++ b/test/external/imports/named-import/ts-esm/source/app.ts
@@ -12,6 +12,13 @@ import {
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
+	async get(key: string): Promise<ClientRateLimitInfo> {
+		return {
+			totalHits: this.hits[key],
+			resetTime: undefined,
+		}
+	}
+
 	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
@@ -24,13 +31,6 @@ export class TestStore implements Store {
 
 	async decrement(key: string): Promise<void> {
 		if (this.hits[key]) this.hits[key]--
-	}
-
-	async fetchKey(key: string): Promise<ClientRateLimitInfo> {
-		return {
-			totalHits: this.hits[key],
-			resetTime: undefined,
-		}
 	}
 
 	async resetKey(key: string): Promise<void> {

--- a/test/external/imports/named-import/ts-esm/source/app.ts
+++ b/test/external/imports/named-import/ts-esm/source/app.ts
@@ -6,13 +6,13 @@ import {
 	rateLimit,
 	MemoryStore,
 	Store,
-	IncrementResponse,
+	ClientRateLimitInfo,
 } from 'express-rate-limit'
 
 export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
-	async increment(key: string): Promise<IncrementResponse> {
+	async increment(key: string): Promise<ClientRateLimitInfo> {
 		if (!this.hits[key]) this.hits[key] = 0
 		this.hits[key] += 1
 

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -119,8 +119,10 @@ describe('headers test', () => {
 					standardHeaders: false,
 				}),
 			)
+
 			const response = await request(app).get('/').expect(200)
 			const rateLimitDetails = parseRateLimit(response as any)
+
 			expect(rateLimitDetails).toMatchObject({
 				used: 1,
 				remaining: 4,
@@ -137,8 +139,10 @@ describe('headers test', () => {
 					standardHeaders: 'draft-6',
 				}),
 			)
+
 			const response = await request(app).get('/').expect(200)
 			const rateLimitDetails = parseRateLimit(response as any)
+
 			expect(rateLimitDetails).toMatchObject({
 				used: 1,
 				remaining: 4,
@@ -156,8 +160,10 @@ describe('headers test', () => {
 					standardHeaders: 'draft-7',
 				}),
 			)
+
 			const response = await request(app).get('/').expect(200)
 			const rateLimitDetails = parseRateLimit(response as any)
+
 			expect(rateLimitDetails).toMatchObject({
 				used: 1,
 				remaining: 4,

--- a/test/library/memory-store-test.ts
+++ b/test/library/memory-store-test.ts
@@ -17,6 +17,20 @@ describe.only('memory store test', () => {
 		jest.restoreAllMocks()
 	})
 
+	it('returns the current hit count and reset time for a key', async () => {
+		const store = new MemoryStore()
+		store.init({ windowMs: minute } as Options)
+		const key = 'test-store'
+
+		await store.increment(key)
+
+		const response = await store.get(key)
+		expect(response).toMatchObject({
+			totalHits: 1,
+			resetTime: expect.any(Date),
+		})
+	})
+
 	it('sets the value to 1 on first call to `increment`', async () => {
 		const store = new MemoryStore()
 		store.init({ windowMs: minute } as Options)

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -29,13 +29,19 @@ describe('middleware test', () => {
 		incrementWasCalled = false
 		decrementWasCalled = false
 		resetKeyWasCalled = false
-		fetchKeyWasCalled = false
+		getWasCalled = false
 		resetAllWasCalled = false
 
 		counter = 0
 
 		init(_options: Options): void {
 			this.initWasCalled = true
+		}
+
+		async get(_key: string): Promise<ClientRateLimitInfo> {
+			this.getWasCalled = true
+
+			return { totalHits: this.counter, resetTime: undefined }
 		}
 
 		async increment(_key: string): Promise<ClientRateLimitInfo> {
@@ -52,12 +58,6 @@ describe('middleware test', () => {
 
 		async resetKey(_key: string): Promise<void> {
 			this.resetKeyWasCalled = true
-		}
-
-		async fetchKey(_key: string): Promise<ClientRateLimitInfo> {
-			this.fetchKeyWasCalled = true
-
-			return { totalHits: this.counter, resetTime: undefined }
 		}
 
 		async resetAll(): Promise<void> {
@@ -100,7 +100,7 @@ describe('middleware test', () => {
 		incrementWasCalled = false
 		decrementWasCalled = false
 		resetKeyWasCalled = false
-		fetchKeyWasCalled = false
+		getWasCalled = false
 		resetAllWasCalled = false
 
 		counter = 0
@@ -110,6 +110,12 @@ describe('middleware test', () => {
 			this.incrementWasCalled = true
 
 			callback(undefined, this.counter, undefined)
+		}
+
+		async get(_key: string): Promise<ClientRateLimitInfo> {
+			this.getWasCalled = true
+
+			return { totalHits: this.counter, resetTime: undefined }
 		}
 
 		async increment(_key: string): Promise<ClientRateLimitInfo> {
@@ -126,12 +132,6 @@ describe('middleware test', () => {
 
 		resetKey(_key: string): void {
 			this.resetKeyWasCalled = true
-		}
-
-		async fetchKey(_key: string): Promise<ClientRateLimitInfo> {
-			this.fetchKeyWasCalled = true
-
-			return { totalHits: this.counter, resetTime: undefined }
 		}
 
 		resetAll(): void {

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -11,7 +11,7 @@ import rateLimit, {
 	type Store,
 	type Options,
 	type IncrementCallback,
-	type IncrementResponse,
+	type ClientRateLimitInfo,
 } from '../../source/index.js'
 import { createServer } from './helpers/create-server.js'
 
@@ -29,6 +29,7 @@ describe('middleware test', () => {
 		incrementWasCalled = false
 		decrementWasCalled = false
 		resetKeyWasCalled = false
+		fetchKeyWasCalled = false
 		resetAllWasCalled = false
 
 		counter = 0
@@ -37,7 +38,7 @@ describe('middleware test', () => {
 			this.initWasCalled = true
 		}
 
-		async increment(_key: string): Promise<IncrementResponse> {
+		async increment(_key: string): Promise<ClientRateLimitInfo> {
 			this.counter += 1
 			this.incrementWasCalled = true
 
@@ -51,6 +52,12 @@ describe('middleware test', () => {
 
 		async resetKey(_key: string): Promise<void> {
 			this.resetKeyWasCalled = true
+		}
+
+		async fetchKey(_key: string): Promise<ClientRateLimitInfo> {
+			this.fetchKeyWasCalled = true
+
+			return { totalHits: this.counter, resetTime: undefined }
 		}
 
 		async resetAll(): Promise<void> {
@@ -93,6 +100,7 @@ describe('middleware test', () => {
 		incrementWasCalled = false
 		decrementWasCalled = false
 		resetKeyWasCalled = false
+		fetchKeyWasCalled = false
 		resetAllWasCalled = false
 
 		counter = 0
@@ -104,7 +112,7 @@ describe('middleware test', () => {
 			callback(undefined, this.counter, undefined)
 		}
 
-		async increment(_key: string): Promise<IncrementResponse> {
+		async increment(_key: string): Promise<ClientRateLimitInfo> {
 			this.counter += 1
 			this.incrementWasCalled = true
 
@@ -118,6 +126,12 @@ describe('middleware test', () => {
 
 		resetKey(_key: string): void {
 			this.resetKeyWasCalled = true
+		}
+
+		async fetchKey(_key: string): Promise<ClientRateLimitInfo> {
+			this.fetchKeyWasCalled = true
+
+			return { totalHits: this.counter, resetTime: undefined }
 		}
 
 		resetAll(): void {

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -422,6 +422,20 @@ describe('middleware test', () => {
 		['modern', new MockStore()],
 		['legacy', new MockLegacyStore()],
 		['compat', new MockBackwardCompatibleStore()],
+	])('should call `get` on the store (%s store)', async (name, store) => {
+		const limiter = rateLimit({
+			store,
+		})
+
+		limiter.getKey('key')
+
+		expect(store.getWasCalled).toEqual(true)
+	})
+
+	it.each([
+		['modern', new MockStore()],
+		['legacy', new MockLegacyStore()],
+		['compat', new MockBackwardCompatibleStore()],
 	])(
 		'should decrement hits when requests succeed and `skipSuccessfulRequests` is set to true (%s store)',
 		async (name, store) => {

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -420,17 +420,30 @@ describe('middleware test', () => {
 
 	it.each([
 		['modern', new MockStore()],
-		['legacy', new MockLegacyStore()],
 		['compat', new MockBackwardCompatibleStore()],
 	])('should call `get` on the store (%s store)', async (name, store) => {
 		const limiter = rateLimit({
 			store,
 		})
 
-		limiter.getKey('key')
+		const response = await limiter.getKey!('key')
 
 		expect(store.getWasCalled).toEqual(true)
+		expect(typeof response?.totalHits).toBe('number')
 	})
+
+	it.each([['legacy', new MockLegacyStore()]])(
+		'should call `get` on the store (%s store)',
+		async (name, store) => {
+			const limiter = rateLimit({
+				store,
+			})
+
+			const response = await limiter.getKey!('key')
+			// The legacy stores are promisified and provided a stub `get` function.
+			expect(response).toBeUndefined()
+		},
+	)
 
 	it.each([
 		['modern', new MockStore()],

--- a/test/library/options-test.ts
+++ b/test/library/options-test.ts
@@ -4,7 +4,7 @@
 import rateLimit, {
 	type Store,
 	type Options,
-	type IncrementResponse,
+	type ClientRateLimitInfo,
 } from '../../source/index.js'
 
 describe('options test', () => {
@@ -15,13 +15,17 @@ describe('options test', () => {
 			this.options = options
 		}
 
-		async increment(_key: string): Promise<IncrementResponse> {
+		async increment(_key: string): Promise<ClientRateLimitInfo> {
 			return { totalHits: 1, resetTime: undefined }
 		}
 
 		async decrement(_key: string): Promise<void> {}
 
 		async resetKey(_key: string): Promise<void> {}
+
+		async fetchKey(_key: string): Promise<ClientRateLimitInfo> {
+			return { totalHits: 1, resetTime: undefined }
+		}
 	}
 
 	// TODO: Update in v7.
@@ -65,7 +69,7 @@ describe('options test', () => {
 			// @ts-expect-error Check if the library can detect invalid stores without TSC's help
 			init = 'not-a-function'
 
-			async increment(_key: string): Promise<IncrementResponse> {
+			async increment(_key: string): Promise<ClientRateLimitInfo> {
 				return { totalHits: 1, resetTime: undefined }
 			}
 

--- a/test/library/options-test.ts
+++ b/test/library/options-test.ts
@@ -15,6 +15,10 @@ describe('options test', () => {
 			this.options = options
 		}
 
+		async get(_key: string): Promise<ClientRateLimitInfo> {
+			return { totalHits: 1, resetTime: undefined }
+		}
+
 		async increment(_key: string): Promise<ClientRateLimitInfo> {
 			return { totalHits: 1, resetTime: undefined }
 		}
@@ -22,10 +26,6 @@ describe('options test', () => {
 		async decrement(_key: string): Promise<void> {}
 
 		async resetKey(_key: string): Promise<void> {}
-
-		async fetchKey(_key: string): Promise<ClientRateLimitInfo> {
-			return { totalHits: 1, resetTime: undefined }
-		}
 	}
 
 	// TODO: Update in v7.


### PR DESCRIPTION
- The function is also bound to the middleware so it can be called externally.

---

This PR fixes #389. The tests are currently failing since the external stores do not yet have the `fetchKey` function.