### PR TITLE
fix: rename current to used, while still supporting current

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -351,7 +351,7 @@ const rateLimit = (
 			Object.defineProperty(info, 'current', {
 				configurable: false,
 				enumerable: false,
-				get: () => (this as unknown as RateLimitInfo).used,
+				value: totalHits,
 			})
 
 			// Set the rate limit information on the augmented request object

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -338,12 +338,21 @@ const rateLimit = (
 			const limit = await retrieveLimit
 			config.validations.max(limit)
 
+			// Define the rate limit info for the client.
 			const info: RateLimitInfo = {
 				limit,
-				current: totalHits,
+				used: totalHits,
 				remaining: Math.max(limit - totalHits, 0),
 				resetTime,
 			}
+
+			// Set the `current` property on the object, but hide it from iteration
+			// and `JSON.stringify`. See the `./types#RateLimitInfo` for details.
+			Object.defineProperty(info, 'current', {
+				configurable: false,
+				enumerable: false,
+				get: () => (this as unknown as RateLimitInfo).used,
+			})
 
 			// Set the rate limit information on the augmented request object
 			augmentedRequest[config.requestPropertyName] = info

--- a/source/types.ts
+++ b/source/types.ts
@@ -328,7 +328,15 @@ export type AugmentedRequest = Request & {
  */
 export type RateLimitInfo = {
 	limit: number
-	current: number
+	used: number
 	remaining: number
 	resetTime: Date | undefined
+
+	/**
+	 * NOTE: The `current` field is deprecated and renamed to `used`. The library
+	 * will still set the `current` property, and you can still access it, but it
+	 * will be hidden from iteration and JSON.stringify calls. See:
+	 * https://github.com/express-rate-limit/express-rate-limit/discussions/372#discussioncomment-6915685
+	 */
+	// current: number
 }

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -95,7 +95,7 @@ describe('headers test', () => {
 		} as any
 		const info: RateLimitInfo = {
 			limit: 5,
-			current: 1,
+			used: 1,
 			remaining: 4,
 			resetTime: new Date(),
 		}

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -750,15 +750,25 @@ describe('middleware test', () => {
 		])
 
 		await request(app).get('/').expect(200)
-		expect(savedRequestObject).toBeTruthy()
-		expect(savedRequestObject.rateLimit).toBeTruthy()
-		expect(savedRequestObject.rateLimit.limit).toEqual(5)
-		expect(savedRequestObject.rateLimit.remaining).toEqual(4)
+		expect(savedRequestObject?.rateLimit).toMatchObject({
+			limit: 5,
+			used: 1,
+			remaining: 4,
+			resetTime: expect.any(Date),
+		})
+
+		// Make sure the hidden proerty is also set.
+		expect(savedRequestObject?.rateLimit.current).toBe(1)
 
 		savedRequestObject = undefined
 		await request(app).get('/').expect(200)
-		expect(savedRequestObject.rateLimit.limit).toEqual(5)
-		expect(savedRequestObject.rateLimit.remaining).toEqual(3)
+		expect(savedRequestObject?.rateLimit).toMatchObject({
+			limit: 5,
+			used: 2,
+			remaining: 3,
+			resetTime: expect.any(Date),
+		})
+		expect(savedRequestObject?.rateLimit.current).toBe(2)
 	})
 
 	it('should pass the number of hits and the limit to the next request handler with a custom property', async () => {
@@ -782,15 +792,23 @@ describe('middleware test', () => {
 		])
 
 		await request(app).get('/').expect(200)
-		expect(savedRequestObject).toBeTruthy()
-		expect(savedRequestObject.rateLimitInfo).toBeTruthy()
-		expect(savedRequestObject.rateLimitInfo.limit).toEqual(5)
-		expect(savedRequestObject.rateLimitInfo.remaining).toEqual(4)
+		expect(savedRequestObject?.rateLimitInfo).toMatchObject({
+			limit: 5,
+			used: 1,
+			remaining: 4,
+			resetTime: expect.any(Date),
+		})
+		expect(savedRequestObject?.rateLimitInfo.current).toBe(1)
 
 		savedRequestObject = undefined
 		await request(app).get('/').expect(200)
-		expect(savedRequestObject.rateLimitInfo.limit).toEqual(5)
-		expect(savedRequestObject.rateLimitInfo.remaining).toEqual(3)
+		expect(savedRequestObject?.rateLimitInfo).toMatchObject({
+			limit: 5,
+			used: 2,
+			remaining: 3,
+			resetTime: expect.any(Date),
+		})
+		expect(savedRequestObject?.rateLimitInfo.current).toBe(2)
 	})
 
 	it('should handle two rate-limiters with different `requestPropertyNames` operating independently', async () => {


### PR DESCRIPTION
- This PR implements https://github.com/express-rate-limit/express-rate-limit/discussions/372#discussioncomment-6915685.

---

We should probably merge this in v7.