### PR TITLE
Allow specific validations to be enabled or disabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -532,8 +532,8 @@ const limiter = rateLimit({
 ```
 
 Supported options are `ip`, `trustProxy`, `xForwardedForHeader`, `positiveHits`,
-`singleCount`, `max`, `draftPolliHeaders`, `onLimitReached`, `headersResetTime`,
-`validationsConfig`, and `default`.
+`singleCount`, `limit`, `draftPolliHeaders`, `onLimitReached`,
+`headersResetTime`, `validationsConfig`, and `default`.
 
 See https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes
 for more info.

--- a/readme.md
+++ b/readme.md
@@ -508,7 +508,7 @@ const limiter = rateLimit({
 
 ### `validate`
 
-> `boolean`
+> `boolean | Object`
 
 When enabled, a set of validation checks are run on the first request to detect
 common misconfigurations with proxies, etc. Prints an error to the console if
@@ -516,10 +516,29 @@ any issue is detected.
 
 Automatically disables after the first request is processed.
 
+If set to `true` or `false`, all validations are enabled or disabled.
+
+If set to an object, individual validations can be enabled or disabled by name,
+and the key `default` controls all unspecified validations. For example:
+
+```js
+const limiter = rateLimit({
+	validate: {
+		xForwardedForHeader: false,
+		default: true,
+	},
+	// ...
+})
+```
+
+Supported options are `ip`, `trustProxy`, `xForwardedForHeader`, `positiveHits`,
+`singleCount`, `max`, `draftPolliHeaders`, `onLimitReached`, `headersResetTime`,
+`validationsConfig`, and `default`.
+
 See https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes
 for more info.
 
-Defaults to true.
+Defaults to `true`.
 
 ### `store`
 

--- a/readme.md
+++ b/readme.md
@@ -510,9 +510,9 @@ const limiter = rateLimit({
 
 > `boolean | Object`
 
-When enabled, a set of validation checks are run on the first request to detect
-common misconfigurations with proxies, etc. Prints an error to the console if
-any issue is detected.
+When enabled, a set of validation checks are run at creation and on the first
+request to detect common misconfigurations with proxies, etc. Prints an error to
+the console if any issue is detected.
 
 Automatically disables after the first request is processed.
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -13,7 +13,7 @@ import type {
 	RateLimitExceededEventHandler,
 	DraftHeadersVersion,
 	RateLimitInfo,
-	ValidationsEnabled,
+	EnabledValidations,
 } from './types.js'
 import {
 	setLegacyHeaders,
@@ -130,7 +130,7 @@ const getOptionsFromConfig = (config: Configuration): Options => {
 
 	return {
 		...directlyPassableEntries,
-		validate: validations.enabled as ValidationsEnabled,
+		validate: validations.enabled as EnabledValidations,
 	}
 }
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -176,6 +176,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 
 	// Create the validator before even parsing the rest of the options.
 	const validations = getValidations(notUndefinedOptions?.validate ?? true)
+	validations.validationsConfig()
 
 	// Warn for the deprecated options. Note that these options have been removed
 	// from the type definitions in v7.

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -13,6 +13,7 @@ import type {
 	RateLimitExceededEventHandler,
 	DraftHeadersVersion,
 	RateLimitInfo,
+	ValidationsEnabled,
 } from './types.js'
 import {
 	setLegacyHeaders,
@@ -129,7 +130,7 @@ const getOptionsFromConfig = (config: Configuration): Options => {
 
 	return {
 		...directlyPassableEntries,
-		validate: validations.enabled,
+		validate: validations.enabled as ValidationsEnabled,
 	}
 }
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -20,7 +20,7 @@ import {
 	setDraft7Headers,
 	setRetryAfterHeader,
 } from './headers.js'
-import { Validations } from './validations.js'
+import { getValidations, type Validations } from './validations.js'
 import MemoryStore from './memory-store.js'
 
 /**
@@ -175,7 +175,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 		omitUndefinedOptions(passedOptions)
 
 	// Create the validator before even parsing the rest of the options.
-	const validations = new Validations(notUndefinedOptions?.validate ?? true)
+	const validations = getValidations(notUndefinedOptions?.validate ?? true)
 
 	// Warn for the deprecated options. Note that these options have been removed
 	// from the type definitions in v7.

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -338,7 +338,7 @@ const rateLimit = (
 					? config.limit(request, response)
 					: config.limit
 			const limit = await retrieveLimit
-			config.validations.max(limit)
+			config.validations.limit(limit)
 
 			const info: RateLimitInfo = {
 				limit,

--- a/source/types.ts
+++ b/source/types.ts
@@ -175,6 +175,12 @@ export type Store = {
 
 export type DraftHeadersVersion = 'draft-6' | 'draft-7'
 
+// Ideally, this should be:
+//   import type { Validations } from './validations.js'
+//   export type ValidationsEnabled = { [key in keyof Validations]: boolean }
+// But that causes a circular reference between the Validations and ValidationsEnabled types, so it doesn't work.
+export type ValidationsEnabled = { [key: string]: boolean }
+
 /**
  * The configuration options for the rate limiter.
  */
@@ -291,7 +297,7 @@ export type Options = {
 	/**
 	 * Whether or not the validation checks should run.
 	 */
-	validate: boolean
+	validate: boolean | ValidationsEnabled
 
 	/**
 	 * Whether to send `X-RateLimit-*` headers with the rate limit and the number

--- a/source/types.ts
+++ b/source/types.ts
@@ -177,7 +177,7 @@ export type Store = {
 export type DraftHeadersVersion = 'draft-6' | 'draft-7'
 
 /**
- * Validations configuration object for enabling or disabeling specific validations
+ * Validate configuration object for enabling or disabeling specific validations
  *
  * The keys must also be keys in the validations object (except `enabled` and `disable`), or `default`
  */

--- a/source/types.ts
+++ b/source/types.ts
@@ -2,6 +2,7 @@
 // All the types used by this package
 
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import type { Validations } from './validations.js'
 
 /**
  * Callback that fires when a client's hit counter is incremented.
@@ -175,11 +176,14 @@ export type Store = {
 
 export type DraftHeadersVersion = 'draft-6' | 'draft-7'
 
-// Ideally, this should be:
-//   import type { Validations } from './validations.js'
-//   export type ValidationsEnabled = { [key in keyof Validations]: boolean }
-// But that causes a circular reference between the Validations and ValidationsEnabled types, so it doesn't work.
-export type ValidationsEnabled = { [key: string]: boolean }
+/**
+ * Validations configuration object for enabling or disabeling specific validations
+ *
+ * The keys must also be keys in the validations object (except `enabled` and `disable`), or `default`
+ */
+export type ValidationsEnabled = {
+	[key in keyof Omit<Validations, 'enabled' | 'disable'> | 'default']?: boolean
+}
 
 /**
  * The configuration options for the rate limiter.

--- a/source/types.ts
+++ b/source/types.ts
@@ -177,11 +177,12 @@ export type Store = {
 export type DraftHeadersVersion = 'draft-6' | 'draft-7'
 
 /**
- * Validate configuration object for enabling or disabeling specific validations
+ * Validate configuration object for enabling or disabling specific validations.
  *
- * The keys must also be keys in the validations object (except `enabled` and `disable`), or `default`
+ * The keys must also be keys in the validations object, except `enable`, `disable`,
+ * and `default`.
  */
-export type ValidationsEnabled = {
+export type EnabledValidations = {
 	[key in keyof Omit<Validations, 'enabled' | 'disable'> | 'default']?: boolean
 }
 
@@ -299,9 +300,9 @@ export type Options = {
 	store: Store | LegacyStore
 
 	/**
-	 * Whether or not the validation checks should run.
+	 * The list of validation checks that should run.
 	 */
-	validate: boolean | ValidationsEnabled
+	validate: boolean | EnabledValidations
 
 	/**
 	 * Whether to send `X-RateLimit-*` headers with the rate limit and the number

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -176,18 +176,18 @@ const validations = {
 	},
 
 	/**
-	 * Warns the user that the behaviour for `max: 0` is changing in the next
+	 * Warns the user that the behaviour for `max: 0` / `limit: 0` is changing in the next
 	 * major release.
 	 *
-	 * @param max {number} - The maximum number of hits per client.
+	 * @param limit {number} - The maximum number of hits per client.
 	 *
 	 * @returns {void}
 	 */
-	max(max: number) {
-		if (max === 0) {
+	limit(limit: number) {
+		if (limit === 0) {
 			throw new ChangeWarning(
 				'WRN_ERL_MAX_ZERO',
-				`Setting max to 0 disables rate limiting in express-rate-limit v6 and older, but will cause all requests to be blocked in v7`,
+				`Setting limit or max to 0 disables rate limiting in express-rate-limit v6 and older, but will cause all requests to be blocked in v7`,
 			)
 		}
 	},

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -242,6 +242,28 @@ const validations = {
 			)
 		}
 	},
+
+	/**
+	 * Checks the options.validate setting to ensure that only recognized validations are enabled or disabled.
+	 *
+	 * If any unrecognized values are found, an error is logged that includes the list of supported vaidations.
+	 */
+	validationsConfig() {
+		const supportedValidations = Object.keys(this).filter(
+			(k) => !['enabled', 'disable'].includes(k),
+		)
+		supportedValidations.push('default')
+		for (const key of Object.keys(this.enabled)) {
+			if (!supportedValidations.includes(key)) {
+				throw new ValidationError(
+					'ERR_ERL_UNKNOWN_VALIDATION',
+					`options.validate.${key} is not recognized. Supported validate options are: ${supportedValidations.join(
+						', ',
+					)}.`,
+				)
+			}
+		}
+	},
 }
 
 export type Validations = typeof validations

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -3,7 +3,7 @@
 
 import { isIP } from 'node:net'
 import type { Request } from 'express'
-import type { Store, ValidationsEnabled } from './types.js'
+import type { Store, EnabledValidations } from './types.js'
 
 /**
  * An error thrown/returned when a validation error occurs.
@@ -56,7 +56,7 @@ const validations = {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 	enabled: {
 		default: true,
-	} as { [key: string]: boolean }, // Should be ValidationsEnabled type, but that's a circular reference
+	} as { [key: string]: boolean }, // Should be EnabledValidations type, but that's a circular reference
 
 	disable() {
 		for (const k of Object.keys(this.enabled)) this.enabled[k] = false
@@ -272,12 +272,13 @@ export type Validations = typeof validations
  * Creates a copy of the validations object where each method is wrapped to catch and log any thrown errors.
  * Sets `enabled` to the provided value, allowing different instances of express-rate-limit to have different validations settings.
  *
- * @param enabled {boolean}
- * @returns {Validations}
+ * @param enabled {boolean} - The list of enabled validations.
+ *
+ * @returns {Validations} - The validation functions.
  */
-export function getValidations(
-	_enabled: boolean | ValidationsEnabled,
-): Validations {
+export const getValidations = (
+	_enabled: boolean | EnabledValidations,
+): Validations => {
 	let enabled: { [key: string]: boolean }
 	if (typeof _enabled === 'boolean') {
 		enabled = {

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -56,7 +56,7 @@ const validations = {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 	enabled: {
 		default: true,
-	} as ValidationsEnabled,
+	} as { [key: string]: boolean }, // Should be ValidationsEnabled type, but that's a circular reference
 
 	disable() {
 		for (const k of Object.keys(this.enabled)) this.enabled[k] = false

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -193,7 +193,7 @@ describe('middleware test', () => {
 	})
 
 	it('should block all requests if max is set to 0', async () => {
-		const app = createServer(rateLimit({ max: 0 }))
+		const app = createServer(rateLimit({ max: 0, validate: { limit: false } }))
 
 		await request(app).get('/').expect(429)
 	})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -233,6 +233,57 @@ describe('validations tests', () => {
 		})
 	})
 
+	describe('validationsConfig', () => {
+		it('should log an error if an unknown validation is disabled', () => {
+			validations = getValidations({ invalid: false } as any)
+			validations.validationsConfig()
+			expect(console.error).toBeCalled()
+		})
+		it('should log an error if an unknown validation is enabled', () => {
+			validations = getValidations({ invalid: false } as any)
+			validations.validationsConfig()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_UNKNOWN_VALIDATION' }),
+			)
+		})
+		it('should not log an error if only valid keys are set', () => {
+			validations = getValidations({
+				ip: false,
+				positiveHits: true,
+				default: false,
+			})
+			validations.validationsConfig()
+			expect(console.error).not.toBeCalled()
+		})
+		it('should not run if disabled by config', () => {
+			validations = getValidations({
+				invalid: false,
+				validationsConfig: false,
+			} as any)
+			validations.validationsConfig()
+			expect(console.error).not.toBeCalled()
+		})
+		it('should not run if disabled by default', () => {
+			validations = getValidations({
+				invalid: true,
+				default: false,
+			} as any)
+			validations.validationsConfig()
+			expect(console.error).not.toBeCalled()
+		})
+		it('should run if enabled by config with default: false', () => {
+			validations = getValidations({
+				invalid: false,
+				validationsConfig: true,
+				default: false,
+			} as any)
+			validations.validationsConfig()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_UNKNOWN_VALIDATION' }),
+			)
+		})
+	})
+
 	describe('disable', () => {
 		it('should initialize disabled when passed false', () => {
 			const disabledValidator = getValidations(false)

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -177,14 +177,14 @@ describe('validations tests', () => {
 		})
 	})
 
-	describe('max', () => {
+	describe('limit', () => {
 		it('should log a warning if max is set to 0', () => {
-			validations.max(0)
+			validations.limit(0)
 			expect(console.warn).toBeCalled()
 		})
 
 		it('should not log a warning if max is set to a non zero number', () => {
-			validations.max(3)
+			validations.limit(3)
 			expect(console.warn).not.toBeCalled()
 		})
 	})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -9,11 +9,11 @@ import {
 	beforeEach,
 	afterEach,
 } from '@jest/globals'
-import { Validations } from '../../source/validations.js'
+import { getValidations } from '../../source/validations.js'
 import type { Store } from '../../source/types'
 
 describe('validations tests', () => {
-	let validations = new Validations(true)
+	let validations = getValidations(true)
 
 	beforeEach(() => {
 		jest.spyOn(console, 'error').mockImplementation(() => {})
@@ -21,7 +21,7 @@ describe('validations tests', () => {
 	})
 	afterEach(() => {
 		jest.restoreAllMocks()
-		validations = new Validations(true)
+		validations = getValidations(true)
 	})
 
 	describe('ip', () => {
@@ -235,7 +235,7 @@ describe('validations tests', () => {
 
 	describe('disable', () => {
 		it('should initialize disabled when passed false', () => {
-			const disabledValidator = new Validations(false)
+			const disabledValidator = getValidations(false)
 			disabledValidator.ip('badip')
 			expect(console.error).not.toBeCalled()
 		})
@@ -244,12 +244,6 @@ describe('validations tests', () => {
 			validations.disable()
 			validations.ip('badip')
 			expect(console.error).not.toBeCalled()
-		})
-
-		it('should be enabled after enable() is called', () => {
-			validations.enable()
-			validations.ip('badip')
-			expect(console.error).toBeCalled()
 		})
 	})
 })

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -236,11 +236,13 @@ describe('validations tests', () => {
 	describe('validationsConfig', () => {
 		it('should log an error if an unknown validation is disabled', () => {
 			validations = getValidations({ invalid: false } as any)
+
 			validations.validationsConfig()
 			expect(console.error).toBeCalled()
 		})
 		it('should log an error if an unknown validation is enabled', () => {
 			validations = getValidations({ invalid: false } as any)
+
 			validations.validationsConfig()
 			expect(console.error).toHaveBeenCalledWith(
 				expect.objectContaining({ code: 'ERR_ERL_UNKNOWN_VALIDATION' }),
@@ -252,6 +254,7 @@ describe('validations tests', () => {
 				positiveHits: true,
 				default: false,
 			})
+
 			validations.validationsConfig()
 			expect(console.error).not.toBeCalled()
 		})
@@ -260,6 +263,7 @@ describe('validations tests', () => {
 				invalid: false,
 				validationsConfig: false,
 			} as any)
+
 			validations.validationsConfig()
 			expect(console.error).not.toBeCalled()
 		})
@@ -268,6 +272,7 @@ describe('validations tests', () => {
 				invalid: true,
 				default: false,
 			} as any)
+
 			validations.validationsConfig()
 			expect(console.error).not.toBeCalled()
 		})
@@ -277,6 +282,7 @@ describe('validations tests', () => {
 				validationsConfig: true,
 				default: false,
 			} as any)
+
 			validations.validationsConfig()
 			expect(console.error).toHaveBeenCalledWith(
 				expect.objectContaining({ code: 'ERR_ERL_UNKNOWN_VALIDATION' }),
@@ -287,12 +293,14 @@ describe('validations tests', () => {
 	describe('disable', () => {
 		it('should initialize disabled when passed false', () => {
 			const disabledValidator = getValidations(false)
+
 			disabledValidator.ip('badip')
 			expect(console.error).not.toBeCalled()
 		})
 
 		it('should do nothing after disable() is called', () => {
 			validations.disable()
+
 			validations.ip('badip')
 			expect(console.error).not.toBeCalled()
 		})


### PR DESCRIPTION
This allows the `validate` option to be set to an object with keys for specific validation checks and boolean values to enable or disable the check. There is also a special `default` key that is used as the fallback value for unset keys. It defaults to `true`. 

It ended up being a kinda big change, but it also fixed the annoyance I had of needing to call `wrap()` inside of each validation check - they're now wrapped automatically - without using decorators!

Todo:
* [x] document change in readme
* [ ] document change on https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes to indicate which key to set to prevent each code
    * This should wait until after v7 is published and/or clarify that v7.0.0 or newer is required for this feature.
* [x] rename `max` check to `limit` so that it has the `limit` key to disable it in  the config
* [x] Fix the `ValidationsEnabled` type to only include the allowed keys
* [x] Tests for various `ValidationsEnabled` configurations
* [x] Tests for the new `validationsConfig()` validation check
* [x] Document `ERR_ERL_UNKNOWN_VALIDATION` on https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes
    * See https://github.com/express-rate-limit/express-rate-limit/wiki/Error-Codes#err_erl_unknown_validation
* [x] Redirect for `ERR_ERL_UNKNOWN_VALIDATION`

Should unblock https://github.com/express-rate-limit/express-slow-down/pull/43

Tip: review  with white space changes omitted: https://github.com/express-rate-limit/express-rate-limit/pull/392/files?w=1

---

I had a couple of other  thoughts that are outside the scope of this PR:
* It'd be nice for Stores to be able to hook into the validations logic, although it'd add a lot of complexity. It'd also probably break intelisense suggestions for `ValidationsEnabled` values. I think we should probably hold off on this for now.
* Some validations might make sense to run on more than the first request. We could allow  `ValidationsEnabled` values to be positive integers, and then decrement it each time the check is run until it gets to `0`. `Infinity` would allow the checks to run indefinitely. I'm not yet sure how I'd handle setting the default value, though.

I think we can ship v7.0.0 without either of those features.