### PR TITLE
fix: consider store prefix in `singleCount` validation check

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -199,6 +199,13 @@ export type Store = {
 	 * Used to help detect double-counting misconfigurations.
 	 */
 	localKeys?: boolean
+
+	/**
+	 * Optional value that the store prepends to keys
+	 *
+	 * Used by the double-count check to avoid false-positives when a key is counted twice, but with different prefixes
+	 */
+	prefix?: string
 }
 
 export type DraftHeadersVersion = 'draft-6' | 'draft-7'

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -183,14 +183,16 @@ export class Validations {
 				storeKeys.set(storeKey, keys)
 			}
 
-			if (keys.includes(key)) {
+			const prefixedKey = `${store.prefix ?? ''}${key}`
+
+			if (keys.includes(prefixedKey)) {
 				throw new ValidationError(
 					'ERR_ERL_DOUBLE_COUNT',
 					`The hit count for ${key} was incremented more than once for a single request.`,
 				)
 			}
 
-			keys.push(key)
+			keys.push(prefixedKey)
 		})
 	}
 

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -130,7 +130,11 @@ describe('validations tests', () => {
 			validations.singleCount(request as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request as any, store as Store, key)
-			expect(console.error).toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					code: 'ERR_ERL_DOUBLE_COUNT',
+				}),
+			)
 		})
 
 		it('should log an error if a request is double-counted with an external store', () => {
@@ -141,7 +145,11 @@ describe('validations tests', () => {
 			validations.singleCount(request as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request as any, store as Store, key)
-			expect(console.error).toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					code: 'ERR_ERL_DOUBLE_COUNT',
+				}),
+			)
 		})
 
 		it('should not log an error if a request is double-counted with separate instances of MemoryStore', () => {
@@ -163,7 +171,11 @@ describe('validations tests', () => {
 
 			validations.singleCount(request as any, store1 as Store, key)
 			validations.singleCount(request as any, store2 as Store, key)
-			expect(console.error).toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					code: 'ERR_ERL_DOUBLE_COUNT',
+				}),
+			)
 		})
 
 		it('should not log an error for multiple requests from the same key', () => {

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -118,7 +118,9 @@ describe('validations tests', () => {
 	})
 
 	describe('singleCount', () => {
-		class TestExternalStore {} // eslint-disable-line @typescript-eslint/no-extraneous-class
+		class TestExternalStore {
+			prefix?: string
+		}
 
 		it('should log an error if a request is double-counted with a MemoryStore', () => {
 			const request = {}
@@ -173,6 +175,19 @@ describe('validations tests', () => {
 			validations.singleCount(request1 as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request2 as any, store as Store, key)
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should not log an error if a request is double-counted with separate instances of an external store with different prefixes', () => {
+			const request = {}
+			const store1 = new TestExternalStore()
+			store1.prefix = 's1'
+			const store2 = new TestExternalStore()
+			store2.prefix = 's2'
+			const key = '1.2.3.4'
+
+			validations.singleCount(request as any, store1 as Store, key)
+			validations.singleCount(request as any, store2 as Store, key)
 			expect(console.error).not.toBeCalled()
 		})
 	})


### PR DESCRIPTION
This makes prefix an optional property on the store Interface (memcached and redis already use it), and then if set, prepends it to keys for the singleCount validation.

Fixes #395 (see #393)