### PR TITLE
fix: restore IncrementResponse type

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -72,6 +72,8 @@ export type ClientRateLimitInfo = {
 	resetTime: Date | undefined
 }
 
+export type IncrementResponse = ClientRateLimitInfo
+
 /**
  * A modified Express request handler with the rate limit functions.
  */
@@ -163,9 +165,9 @@ export type Store = {
 	 *
 	 * @param key {string} - The identifier for a client.
 	 *
-	 * @returns {ClientRateLimitInfo | undefined} - The number of hits and reset time for that client.
+	 * @returns {IncrementResponse | undefined} - The number of hits and reset time for that client.
 	 */
-	increment: (key: string) => Promise<ClientRateLimitInfo> | ClientRateLimitInfo
+	increment: (key: string) => Promise<IncrementResponse> | IncrementResponse
 
 	/**
 	 * Method to decrement a client's hit counter.

--- a/test/external/stores/package.json
+++ b/test/external/stores/package.json
@@ -7,7 +7,6 @@
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --forceExit"
 	},
 	"dependencies": {
-		"@types/rate-limit-redis": "^1.7.4",
 		"express": "^4.18.2",
 		"express-rate-limit": "file:../../..",
 		"precise-memory-rate-limit": "^1.1.4",

--- a/test/external/stores/pnpm-lock.yaml
+++ b/test/external/stores/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@types/rate-limit-redis':
-    specifier: ^1.7.4
-    version: 1.7.4
   express:
     specifier: ^4.18.2
     version: 4.18.2
@@ -1160,19 +1157,6 @@ packages:
       {
         integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==,
       }
-
-  /@types/rate-limit-redis@1.7.4:
-    resolution:
-      {
-        integrity: sha512-TDsh9CJHHhx+sGHlqF6MI+PgEv91o/wQ67e2IR02ebYPzWQ8Rk0pcVY+WBy2pjxa+cAkPwjcOFDd21VToKaOzQ==,
-      }
-    dependencies:
-      '@types/express-rate-limit': 3.3.5
-      '@types/ioredis': 5.0.0
-      '@types/redis': 2.8.32
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@types/redis@2.8.32:
     resolution:


### PR DESCRIPTION
Restores `IncrementResponse ` as an alias of `ClientRateLimitInfo`

fixes https://github.com/express-rate-limit/rate-limit-redis/pull/192 (hopefully)