### PR TITLE
feat: make getKey throw if the store doesn't have a get method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -555,7 +555,8 @@ to complete a captcha to reset their rate limit, then call this function.
 Retrieves the hit count and reset time from the store for a given key.
 
 Note: `getKey` depends on store support. It works with the MemoryStore, but may
-not work with other stores.
+not work with other stores. Calling it will throw an error if the store does not
+have a `get` method.
 
 ## Issues and Contributing
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -436,9 +436,13 @@ const rateLimit = (
 	// client based on their identifier.
 	;(middleware as RateLimitRequestHandler).resetKey =
 		config.store.resetKey.bind(config.store)
-	;(middleware as RateLimitRequestHandler).getKey = config.store.get?.bind(
-		config.store,
-	)
+	;(middleware as RateLimitRequestHandler).getKey =
+		config.store.get?.bind(config.store) ??
+		(() => {
+			throw new Error(
+				'The current store does not support the get/getKey method',
+			)
+		})
 
 	return middleware as RateLimitRequestHandler
 }


### PR DESCRIPTION
Still needs to be tested.

Relates to #404