### PR TITLE
chore: add npm run docs command, remove docs/ prefix from urls

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://mintlify.com/schema.json",
 	"name": "express-rate-limit",
-	"favicon": "docs/assets/icon.png",
+	"favicon": "assets/icon.png",
 	"colors": {
 		"primary": "#9563FF",
 		"light": "#AE87FF",
@@ -21,22 +21,22 @@
 	"navigation": [
 		{
 			"group": "",
-			"pages": ["docs/overview"]
+			"pages": ["overview"]
 		},
 		{
 			"group": "Quickstart",
-			"pages": ["docs/quickstart/installation", "docs/quickstart/usage"]
+			"pages": ["quickstart/installation", "quickstart/usage"]
 		},
 		{
 			"group": "Reference",
-			"pages": ["docs/reference/configuration", "docs/reference/error-codes"]
+			"pages": ["reference/configuration", "reference/error-codes"]
 		},
 		{
 			"group": "Guides",
 			"pages": [
-				"docs/guides/troubleshooting-proxy-issues",
-				"docs/guides/creating-a-store",
-				"docs/guides/contributing"
+				"guides/troubleshooting-proxy-issues",
+				"guides/creating-a-store",
+				"guides/contributing"
 			]
 		}
 	],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"build:esm": "esbuild --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
 		"build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts dist/index.d.mts",
 		"compile": "run-s clean build:*",
-		"docs": "mintlify dev",
+		"docs": "cd docs && mintlify dev",
 		"lint:code": "xo",
 		"lint:rest": "prettier --check .",
 		"lint": "run-s lint:*",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"build:esm": "esbuild --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
 		"build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts dist/index.d.mts",
 		"compile": "run-s clean build:*",
+		"docs": "mintlify dev",
 		"lint:code": "xo",
 		"lint:rest": "prettier --check .",
 		"lint": "run-s lint:*",


### PR DESCRIPTION
I added this, but it doesn't seem to actually work. The server starts, but then it just hangs. I left it running overnight last night, and there was an error, I think it was something about a recursive symlink with express-rate-limit trying to load itself from the node_modules folder, but I accidentally lost the the full error message. I have the command running again, hoping to get it to print the error message.