### PR TITLE
chore: loosen peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"prepare": "run-s compile && husky install config/husky"
 	},
 	"peerDependencies": {
-		"express": "4 || 5"
+		"express": "4 || 5 || ^5.0.0-beta.1"
 	},
 	"devDependencies": {
 		"@express-rate-limit/prettier": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"prepare": "run-s compile && husky install config/husky"
 	},
 	"peerDependencies": {
-		"express": "^4 || ^5"
+		"express": "4 || 5"
 	},
 	"devDependencies": {
 		"@express-rate-limit/prettier": "1.1.1",


### PR DESCRIPTION
Loosen up the peer dependencies to allow express 5 beta with npm's newer peer dependency resolution method.

Fixes https://github.com/express-rate-limit/express-rate-limit/issues/415 (hopefully)