### PR TITLE
chore: move changelog to docs folder/mintlify

### DIFF
--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -67,6 +67,8 @@ express-rate-limit/
 ├── config/
 │  └── husky/
 │     └── pre-commit # runs the linter on staged files
+├── docs/
+│  └── * # documentation & changelog
 ├── source/
 │  ├── headers.ts # header parsing functions
 │  ├── index.ts # exports the types and the middleware
@@ -83,7 +85,6 @@ express-rate-limit/
 │     ├── helpers
 │     │  └── create-server.ts # creates a test express server
 │     └── *-test.ts # tests for each file in the `source/` folder
-├── changelog.md # list of changes made in each version
 ├── license.md # license info
 ├── package-lock.json # npm lock file, do not modify manually
 ├── package.json # node package info

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -29,7 +29,11 @@
 		},
 		{
 			"group": "Reference",
-			"pages": ["reference/configuration", "reference/error-codes"]
+			"pages": [
+				"reference/configuration",
+				"reference/error-codes",
+				"reference/changelog"
+			]
 		},
 		{
 			"group": "Guides",

--- a/docs/quickstart/installation.mdx
+++ b/docs/quickstart/installation.mdx
@@ -51,4 +51,4 @@ This library can be installed from the
 </Tabs>
 
 You can view the changes made in each version in the
-[changelog](https://github.com/express-rate-limit/express-rate-limit/blob/main/changelog.md).
+[changelog](../reference/changelog).

--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -1,4 +1,7 @@
-# Changelog
+---
+title: 'Changelog'
+icon: 'memo'
+---
 
 All notable changes to this project will be documented in this file.
 

--- a/package.json
+++ b/package.json
@@ -48,11 +48,7 @@
 	"types": "./dist/index.d.ts",
 	"files": [
 		"dist/",
-		"tsconfig.json",
-		"package.json",
-		"readme.md",
-		"license.md",
-		"changelog.md"
+		"tsconfig.json"
 	],
 	"engines": {
 		"node": ">= 16"


### PR DESCRIPTION
Also removed the changelog and some other files from what gets published to npm. I think it's pretty rare for users to look in `node_modules` for documentation (especially for something like this that's designed for online use), and npm automatically includes the bits it needs (like the readme & package.json), so we don't need to specify those. 

It won't make a huge difference in file size, but multiplied by millions of downloads per week, it starts to add up to something significant.

(I originally noticed that we had a [broken link to docs/changelog.md](https://github.com/express-rate-limit/express-rate-limit/blob/v7.1.4/docs/quickstart/installation.mdx#L54) so I fixed that and some other broken links and pushed the fix to `main` right away, but then I thought it probably would make sense to move the changelog over to the docs.)