### PR TITLE
fix: ci generation config of the url for changelog

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,4 +96,4 @@ jobs:
           files: express-rate-limit.tgz
           body:
             You can view the changelog
-            [here](https://github.com/express-rate-limit/express-rate-limit/blob/main/changelog.md).
+            [here](https://express-rate-limit.mintlify.app/reference/changelog).


### PR DESCRIPTION
* Affects https://github.com/express-rate-limit/express-rate-limit/releases pages
* Assume directing devs/users to offsite area instead of [current dev location](https://github.com/express-rate-limit/express-rate-limit/blob/main/docs/reference/changelog.mdx)

Post #420