### PR TITLE
Bugfix: requestWasSuccessful usage doesn't support returning a Promise

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -389,7 +389,7 @@ const rateLimit = (
 
 				if (config.skipFailedRequests) {
 					response.on('finish', async () => {
-						if (!config.requestWasSuccessful(request, response))
+						if (!(await config.requestWasSuccessful(request, response)))
 							await decrementKey()
 					})
 					response.on('close', async () => {
@@ -402,7 +402,7 @@ const rateLimit = (
 
 				if (config.skipSuccessfulRequests) {
 					response.on('finish', async () => {
-						if (config.requestWasSuccessful(request, response))
+						if (await config.requestWasSuccessful(request, response))
 							await decrementKey()
 					})
 				}

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -611,6 +611,26 @@ describe('middleware test', () => {
 		},
 	)
 
+	it.each([
+		['modern', new MockStore()],
+		['legacy', new MockLegacyStore()],
+		['compat', new MockBackwardCompatibleStore()],
+	])(
+		'should decrement hits when requests fail, `skipFailedRequests` is set to true and a custom `requestWasSuccessful` method used that returns a promise (%s store)',
+		async (name, store) => {
+			const app = createServer(
+				rateLimit({
+					skipFailedRequests: true,
+					requestWasSuccessful: async () => false,
+					store,
+				}),
+			)
+
+			await request(app).get('/').expect(200)
+			expect(store.decrementWasCalled).toEqual(true)
+		},
+	)
+
 	// FIXME: This test times out  _sometimes_ on MacOS and Windows, so it is disabled for now
 	/*
 	;(platform === 'darwin' ? it.skip : it).each([


### PR DESCRIPTION
Fixes https://github.com/express-rate-limit/express-rate-limit/issues/425

The added test case fails on `main` but succeeds on this branch.