### PR TITLE
docs: Create Data Stores documentation page

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -31,6 +31,7 @@
 			"group": "Reference",
 			"pages": [
 				"reference/configuration",
+				"reference/stores",
 				"reference/instance-api",
 				"reference/request-api",
 				"reference/error-codes",

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -33,7 +33,7 @@ is probably fine.
 ### API Rate Limit Enforcement
 
 If you have multiple servers, or want to maintain state across app restarts, use
-an [external data store](/reference/configuration#store).
+an [external data store](/reference/stores).
 
 If you have multiple processes on a single server (via the
 [node:cluster](https://nodejs.org/api/cluster.html) module), you could use the

--- a/docs/quickstart/usage.mdx
+++ b/docs/quickstart/usage.mdx
@@ -100,8 +100,7 @@ const limiter = rateLimit({
 })
 ```
 
-For a list of stores you can use, and for more information on the `store`
-option, take a look at the [config page](references/configuration#store).
+For a list of stores you can use, take a look at the [data stores page](references/stores).
 
 For a tutorial on how to create your own store, see
 [this](/guides/creating-a-store).

--- a/docs/quickstart/usage.mdx
+++ b/docs/quickstart/usage.mdx
@@ -100,7 +100,8 @@ const limiter = rateLimit({
 })
 ```
 
-For a list of stores you can use, take a look at the [data stores page](references/stores).
+For a list of stores you can use, take a look at the
+[data stores page](references/stores).
 
 For a tutorial on how to create your own store, see
 [this](/guides/creating-a-store).

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -13,7 +13,7 @@ Time frame for which requests are checked/remembered. Also used in the
 <Note>
 
 For stores that do not implement the `init` function (see the
-[stores table](#stores) below), you may need to configure this value twice, once
+[data stores page](/reference/stores)), you may need to configure this value twice, once
 here and once on the store. In some cases the units also differ (e.g. seconds vs
 miliseconds).
 
@@ -362,17 +362,4 @@ By default, the
 [`memory-store`](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts)
 is used.
 
-Here is a list of external stores:
-
-| Name                                                                                                      | Description                                                                                                                                   | Legacy/Modern       |
-| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| [memory-store](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts) | _(default)_ Simple in-memory option. Does not share state when app has multiple processes or servers.                                         | Modern as of v6.0.0 |
-| [cluster-memory-store](https://npm.im/@express-rate-limit/cluster-memory-store)                           | A memory-store wrapper that shares state across all processes on a server via the [node:cluster](https://nodejs.org/api/cluster.html) module. | Modern              |
-| [rate-limit-redis](https://npm.im/rate-limit-redis)                                                       | A [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.                                                   | Modern as of v3.0.0 |
-| [rate-limit-memcached](https://npmjs.org/package/rate-limit-memcached)                                    | A [Memcached](https://memcached.org/)-backed store.                                                                                           | Modern as of v1.0.0 |
-| [rate-limit-mongo](https://www.npm.im/rate-limit-mongo)                                                   | A [MongoDB](https://www.mongodb.com/)-backed store.                                                                                           | Legacy              |
-| [precise-memory-rate-limit](https://www.npm.im/precise-memory-rate-limit)                                 | A memory store similar to the built-in one, except that it stores a distinct timestamp for each key.                                          | Modern as of v2.0.0 |
-| [rate-limit-postgresql](https://www.npm.im/@acpr/rate-limit-postgresql)                                   | A [PostgreSQL](https://www.postgresql.org/)-backed store.                                                                                     | Modern as of v1.1.0 |
-
-Take a look at [this guide](/guides/creating-a-store) if you wish to create your
-own store.
+See [Data Stores](/reference/stores) for a list of avaliable stores and other information.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -13,9 +13,9 @@ Time frame for which requests are checked/remembered. Also used in the
 <Note>
 
 For stores that do not implement the `init` function (see the
-[data stores page](/reference/stores)), you may need to configure this value twice, once
-here and once on the store. In some cases the units also differ (e.g. seconds vs
-miliseconds).
+[data stores page](/reference/stores)), you may need to configure this value
+twice, once here and once on the store. In some cases the units also differ
+(e.g. seconds vs miliseconds).
 
 </Note>
 
@@ -362,4 +362,5 @@ By default, the
 [`memory-store`](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts)
 is used.
 
-See [Data Stores](/reference/stores) for a list of avaliable stores and other information.
+See [Data Stores](/reference/stores) for a list of avaliable stores and other
+information.

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -154,7 +154,7 @@ a default value of 60 seconds if not explicitly set.
 
 To resolve this, either change to a different headers version, such as
 `draft-6`, or a different
-[store](https://github.com/express-rate-limit/express-rate-limit#store).
+[store](/reference/stores).
 
 Set `validate: {headersResetTime: false}` in the options to disable the check.
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -153,8 +153,7 @@ The library attempts to account for this by using the `windowMs` time, which has
 a default value of 60 seconds if not explicitly set.
 
 To resolve this, either change to a different headers version, such as
-`draft-6`, or a different
-[store](/reference/stores).
+`draft-6`, or a different [store](/reference/stores).
 
 Set `validate: {headersResetTime: false}` in the options to disable the check.
 

--- a/docs/reference/stores.mdx
+++ b/docs/reference/stores.mdx
@@ -3,25 +3,29 @@ title: 'Data Stores'
 icon: 'database'
 ---
 
-Express-rate-limit supports external data stores to sychronize hit counts across multiple processes and servers.
+Express-rate-limit supports external data stores to sychronize hit counts across
+multiple processes and servers.
 
 By default, the built-in
 [`memory-store`](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts)
-is used. This one does not synchronize it's state across instances. It's simple to deploy, and often sufficient for basic abuse prevention, but will be inconnsistent across reboots or in deployments with multiple process or servers.
+is used. This one does not synchronize it's state across instances. It's simple
+to deploy, and often sufficient for basic abuse prevention, but will be
+inconnsistent across reboots or in deployments with multiple process or servers.
 
-Deployments requiring more consistently enforced rate limits should use an external store.
+Deployments requiring more consistently enforced rate limits should use an
+external store.
 
 Here is a list of known stores:
 
-| Name                                                                                                      | Description                                                                                                                                   | Legacy/Modern API   |
-| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| [memory-store](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts) | _(default)_ Simple in-memory option. Does not share state when app has multiple processes or servers.                                         | Modern as of v6.0.0 |
+| Name                                                                                                      | Description                                                                                                                                                                                        | Legacy/Modern API   |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| [memory-store](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts) | _(default)_ Simple in-memory option. Does not share state when app has multiple processes or servers.                                                                                              | Modern as of v6.0.0 |
 | [cluster-memory-store](https://npm.im/@express-rate-limit/cluster-memory-store)                           | A memory-store wrapper that shares state across all processes on a single server via the [node:cluster](https://nodejs.org/api/cluster.html) module. Does not share state across multiple servers. | Modern              |
-| [rate-limit-redis](https://npm.im/rate-limit-redis)                                                       | A [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.                                                   | Modern as of v3.0.0 |
-| [rate-limit-memcached](https://npmjs.org/package/rate-limit-memcached)                                    | A [Memcached](https://memcached.org/)-backed store.                                                                                           | Modern as of v1.0.0 |
-| [rate-limit-mongo](https://www.npm.im/rate-limit-mongo)                                                   | A [MongoDB](https://www.mongodb.com/)-backed store.                                                                                           | Legacy              |
-| [precise-memory-rate-limit](https://www.npm.im/precise-memory-rate-limit)                                 | A memory store similar to the built-in one, except that it stores a distinct timestamp for each key.                                          | Modern as of v2.0.0 |
-| [rate-limit-postgresql](https://www.npm.im/@acpr/rate-limit-postgresql)                                   | A [PostgreSQL](https://www.postgresql.org/)-backed store.                                                                                     | Modern as of v1.1.0 |
+| [rate-limit-redis](https://npm.im/rate-limit-redis)                                                       | A [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.                                                                                                        | Modern as of v3.0.0 |
+| [rate-limit-memcached](https://npmjs.org/package/rate-limit-memcached)                                    | A [Memcached](https://memcached.org/)-backed store.                                                                                                                                                | Modern as of v1.0.0 |
+| [rate-limit-mongo](https://www.npm.im/rate-limit-mongo)                                                   | A [MongoDB](https://www.mongodb.com/)-backed store.                                                                                                                                                | Legacy              |
+| [precise-memory-rate-limit](https://www.npm.im/precise-memory-rate-limit)                                 | A memory store similar to the built-in one, except that it stores a distinct timestamp for each key.                                                                                               | Modern as of v2.0.0 |
+| [rate-limit-postgresql](https://www.npm.im/@acpr/rate-limit-postgresql)                                   | A [PostgreSQL](https://www.postgresql.org/)-backed store.                                                                                                                                          | Modern as of v1.1.0 |
 
 Take a look at [this guide](/guides/creating-a-store) if you wish to create your
 own store.

--- a/docs/reference/stores.mdx
+++ b/docs/reference/stores.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Data Stores'
+icon: 'database'
+---
+
+Express-rate-limit supports external data stores to sychronize hit counts across multiple processes and servers.
+
+By default, the built-in
+[`memory-store`](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts)
+is used. This one does not synchronize it's state across instances. It's simple to deploy, and often sufficient for basic abuse prevention, but will be inconnsistent across reboots or in deployments with multiple process or servers.
+
+Deployments requiring more consistently enforced rate limits should use an external store.
+
+Here is a list of known stores:
+
+| Name                                                                                                      | Description                                                                                                                                   | Legacy/Modern API   |
+| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| [memory-store](https://github.com/express-rate-limit/express-rate-limit/blob/main/source/memory-store.ts) | _(default)_ Simple in-memory option. Does not share state when app has multiple processes or servers.                                         | Modern as of v6.0.0 |
+| [cluster-memory-store](https://npm.im/@express-rate-limit/cluster-memory-store)                           | A memory-store wrapper that shares state across all processes on a single server via the [node:cluster](https://nodejs.org/api/cluster.html) module. Does not share state across multiple servers. | Modern              |
+| [rate-limit-redis](https://npm.im/rate-limit-redis)                                                       | A [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.                                                   | Modern as of v3.0.0 |
+| [rate-limit-memcached](https://npmjs.org/package/rate-limit-memcached)                                    | A [Memcached](https://memcached.org/)-backed store.                                                                                           | Modern as of v1.0.0 |
+| [rate-limit-mongo](https://www.npm.im/rate-limit-mongo)                                                   | A [MongoDB](https://www.mongodb.com/)-backed store.                                                                                           | Legacy              |
+| [precise-memory-rate-limit](https://www.npm.im/precise-memory-rate-limit)                                 | A memory store similar to the built-in one, except that it stores a distinct timestamp for each key.                                          | Modern as of v2.0.0 |
+| [rate-limit-postgresql](https://www.npm.im/@acpr/rate-limit-postgresql)                                   | A [PostgreSQL](https://www.postgresql.org/)-backed store.                                                                                     | Modern as of v1.1.0 |
+
+Take a look at [this guide](/guides/creating-a-store) if you wish to create your
+own store.

--- a/readme.md
+++ b/readme.md
@@ -38,12 +38,17 @@ const limiter = rateLimit({
 	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes).
 	standardHeaders: 'draft-7', // draft-6: `RateLimit-*` headers; draft-7: combined `RateLimit` header
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers.
-	// store: ... , // Use an external store for consistency across multiple server instances.
+	// store: ... , // Redis, Memcached, etc. See below.
 })
 
 // Apply the rate limiting middleware to all requests.
 app.use(limiter)
 ```
+
+### Data Store
+
+Express-rate-limit has a built-in memory store, and supports a variety of
+[external data stores](https://express-rate-limit.mintlify.app/reference/stores).
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -38,16 +38,16 @@ const limiter = rateLimit({
 	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes).
 	standardHeaders: 'draft-7', // draft-6: `RateLimit-*` headers; draft-7: combined `RateLimit` header
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers.
-	// store: ... , // Redis, Memcached, etc. See below.
+	// store: ... , // Redis, Memcached, etc. See the `Data Stores` section below.
 })
 
 // Apply the rate limiting middleware to all requests.
 app.use(limiter)
 ```
 
-### Data Store
+### Data Stores
 
-Express-rate-limit has a built-in memory store, and supports a variety of
+The rate limiter comes with a built-in memory store, and supports a variety of
 [external data stores](https://express-rate-limit.mintlify.app/reference/stores).
 
 ---


### PR DESCRIPTION
This moves the list of stores from the bottom of the Configuration page to a new Data Stores page, and makes a few other changes to make it a little more prominent.

Closes #432