### PR TITLE
Check for instance creation while handling a request

### DIFF
--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -348,6 +348,7 @@ Supported validations are:
 - [draftPolliHeaders](/reference/error-codes#wrn-erl-deprecated-draft-polli-headers)
 - [onLimitReached](/reference/error-codes#wrn-erl-deprecated-on-limit-reached)
 - [headersResetTime](/reference/error-codes#err-erl-headers-no-reset)
+- [creationStack](/reference/error-codes#err-erl-created-in-request-handler)
 - [validationsConfig](/reference/error-codes#err-erl-unknown-validation)
 
 Defaults to `true`.

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -187,6 +187,38 @@ const limiter = rateLimit({
 
 Set `validate: {validationsConfig: false}` in the options to disable the check.
 
+### `ERR_ERL_CREATED_IN_REQUEST_HANDLER`
+
+Instances of express-rate-limit should be created before a request comes in, not
+in response to one.
+
+Incorrect example:
+
+```js
+import { rateLimit } from 'express-rate-limit'
+
+app.use((req, res, next) => {
+	// This won't work!
+	rateLimit({
+		/*...*/
+	})
+	next()
+})
+```
+
+Correct example:
+
+```js
+import { rateLimit } from 'express-rate-limit'
+
+app.use(rateLimit({/*...*/});
+```
+
+To only apply the rate limit to some requests, use the
+[`skip`](/reference/configuration#skip),
+[`skipSuccessfulRequests`](/reference/configuration#skipsuccessfulrequests), or
+[`skipFailedRequests`](/reference/configuration#skipfailedrequests) options.
+
 ## Warnings
 
 ### `WRN_ERL_MAX_ZERO`

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -219,6 +219,26 @@ To only apply the rate limit to some requests, use the
 [`skipSuccessfulRequests`](/reference/configuration#skipsuccessfulrequests), or
 [`skipFailedRequests`](/reference/configuration#skipfailedrequests) options.
 
+Example where the rate limit only applies to users who are not logged in:
+
+```js
+// first determine the user's logged-in status
+app.use((req, res, next) => {
+	if (/* user is logged in */) {
+		req.isLoggedIn = true
+	} else {
+		req.isLoggedIn = false
+	}
+	next()
+})
+
+// next configure express-rate-limit to skip logged in users
+app.use(rateLimit({
+	skip: (req, res) => req.isLoggedIn,
+	// ...
+}))
+```
+
 ## Warnings
 
 ### `WRN_ERL_MAX_ZERO`

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -307,6 +307,8 @@ const rateLimit = (
 	const config = parseOptions(passedOptions ?? {})
 	const options = getOptionsFromConfig(config)
 
+	config.validations.middleware()
+
 	// Call the `init` method on the store, if it exists
 	if (typeof config.store.init === 'function') config.store.init(options)
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -307,7 +307,7 @@ const rateLimit = (
 	const config = parseOptions(passedOptions ?? {})
 	const options = getOptionsFromConfig(config)
 
-	config.validations.middleware()
+	config.validations.creationStack()
 
 	// Call the `init` method on the store, if it exists
 	if (typeof config.store.init === 'function') config.store.init(options)

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -270,15 +270,14 @@ const validations = {
 	/**
 	 * Checks to see if the instance was created inside of a request handler, which would prevent it from working correctly.
 	 */
-	middleware() {
-		if (
-			new Error(
-				'express-rate-limit middleware validation check (set options.validate.middleware = false to disable)',
-			).stack?.includes('Layer.handle [as handle_request]')
-		) {
+	creationStack() {
+		const { stack } = new Error(
+			'express-rate-limit validation check (set options.validate.creationStack=false to disable)',
+		)
+		if (stack?.includes('Layer.handle [as handle_request]')) {
 			throw new ValidationError(
 				'ERR_ERL_CREATED_IN_REQUEST_HANDLER',
-				`express-rate-limit instances should be created at app initialization, not when responding to a request.`,
+				`express-rate-limit instance should be created at app initialization, not when responding to a request.`,
 			)
 		}
 	},

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -266,6 +266,22 @@ const validations = {
 			}
 		}
 	},
+
+	/**
+	 * Checks to see if the instance was created inside of a request handler, which would prevent it from working correctly.
+	 */
+	middleware() {
+		if (
+			new Error(
+				'express-rate-limit middleware validation check (set options.validate.middleware = false to disable)',
+			).stack?.includes('Layer.handle [as handle_request]')
+		) {
+			throw new ValidationError(
+				'ERR_ERL_CREATED_IN_REQUEST_HANDLER',
+				`express-rate-limit instances should be created at app initialization, not when responding to a request.`,
+			)
+		}
+	},
 }
 
 export type Validations = typeof validations


### PR DESCRIPTION
This is one of the ideas I wrote down on https://github.com/express-rate-limit/express-rate-limit/discussions/436 - it seems to work but I'm not yet certain I want to go with it. Also, I think it needs a better name than 'middleware'.