### PR TITLE
meta : export getValidations function

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -11,3 +11,6 @@ export { default, default as rateLimit } from './lib.js'
 // Export the memory store in case someone wants to use or extend it
 // (see https://github.com/nfriedly/express-rate-limit/issues/289)
 export { default as MemoryStore } from './memory-store.js'
+
+// Export getValidations function
+export { getValidations } from './validations.js'


### PR DESCRIPTION
```
		keyGenerator(request: Request, _response: Response): string {
			// Run the validation checks on the IP and headers to make sure everything
			// is working as intended.
			validations.ip(request.ip)
			validations.trustProxy(request)
			validations.xForwardedForHeader(request)

			// By default, use the IP address to rate limit users.
			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
			return request.ip!
		},
```
above code is default keyGenerator.
I wanna make custom keyGenerator that is based on default keyGenerator.
For using validations, I have to call `getValidations` function.
But getValidations is not exported.
That's why I made this pr. Thank you : )