### PR TITLE
docs: prefer limit over max

### DIFF
--- a/docs/quickstart/usage.mdx
+++ b/docs/quickstart/usage.mdx
@@ -41,7 +41,7 @@ An example with the recommended configuration is as follows:
 ```ts
 const limiter = rateLimit({
 	windowMs: 15 * 60 * 1000, // 15 minutes
-	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 })


### PR DESCRIPTION
v7 prefers the naming limit over max. This aligns the preference on the quickstart docs.