### PR TITLE
feat: storePerLimiter validation check

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.2.1)
+
+### Added
+
+- New `storePerLimiter` validation check that identifies cases where a single
+  store instance is shared across multiple limiters
+
 ## [7.2.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.2.0)
 
 ### Added

--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -13,7 +13,7 @@ and this project adheres to
 
 ### Added
 
-- New `storePerLimiter` validation check that identifies cases where a single
+- New `unsharedStore` validation check that identifies cases where a single
   store instance is shared across multiple limiters
 
 ## [7.2.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.2.0)

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -345,6 +345,7 @@ Supported validations are:
 - [trustProxy](/reference/error-codes#err-erl-permissive-trust-proxy)
 - [xForwardedForHeader](/reference/error-codes#err-erl-unexpected-x-forwarded-for)
 - [positiveHits](/reference/error-codes#err-erl-invalid-hits)
+- [unsharedStore](/reference/error-codes#err-erl-store-reuse)
 - [singleCount](/reference/error-codes#err-erl-double-count)
 - [limit](/reference/error-codes#wrn-erl-max-zero) (Note: the `limit` option was
   renamed to `max`, but the validation name did not change.)

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -120,7 +120,7 @@ multiple times, and inconsistent reset times.
 Instead, create a new store instance for each rate limiter. (Generally with a
 unique `prefix` value for each one.)
 
-Set `validate: {storePerLimiter: false}` in the options to disable the check.
+Set `validate: {unsharedStore: false}` in the options to disable the check.
 
 ### `ERR_ERL_DOUBLE_COUNT`
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -109,6 +109,19 @@ error.
 
 Set `validate: {positiveHits: false}` in the options to disable the check.
 
+### `ERR_ERL_STORE_REUSE`
+
+> Added in `7.3.0`.
+
+This indicates that the single [Store](./stores) instance was used in more than
+one rate limiter. This can lead to problems such as initialization logic runing
+multiple times, and inconsistent reset times.
+
+Instead, create a new store instance for each rate limiter. (Generally with a
+unique `prefix` value for each one.)
+
+Set `validate: {storePerLimiter: false}` in the options to disable the check.
+
 ### `ERR_ERL_DOUBLE_COUNT`
 
 > Added in `6.9.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14338,9 +14338,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-			"integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
 			"dependencies": {
 				"chownr": "^2.0.0",
@@ -26196,9 +26196,9 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-			"integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
 			"requires": {
 				"chownr": "^2.0.0",

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -310,7 +310,7 @@ const rateLimit = (
 	// The limiter shouldn't be created in response to a request
 	config.validations.creationStack()
 	// The store instance shouldn't be shared across multiple limiters
-	config.validations.storePerLimiter(config.store)
+	config.validations.unsharedStore(config.store)
 
 	// Call the `init` method on the store, if it exists
 	if (typeof config.store.init === 'function') config.store.init(options)

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -307,7 +307,10 @@ const rateLimit = (
 	const config = parseOptions(passedOptions ?? {})
 	const options = getOptionsFromConfig(config)
 
+	// The limiter shouldn't be created in response to a request
 	config.validations.creationStack()
+	// The store instance shouldn't be shared across multiple limiters
+	config.validations.storePerLimiter(config.store)
 
 	// Call the `init` method on the store, if it exists
 	if (typeof config.store.init === 'function') config.store.init(options)

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -150,7 +150,7 @@ const validations = {
 	/**
 	 * Ensures a single store instance is not used with multiple express-rate-limit instances
 	 */
-	storePerLimiter(store: Store) {
+	unsharedStore(store: Store) {
 		if (usedStores.has(store)) {
 			const maybeUniquePrefix = store?.localKeys
 				? ''

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -380,9 +380,7 @@ describe('middleware test', () => {
 			.expect((response) => {
 				if ('retry-after' in response.headers) {
 					throw new Error(
-						`Expected no retry-after header, got ${
-							response.headers['retry-after'] as string
-						}`,
+						`Expected no retry-after header, got ${response.headers['retry-after']}`,
 					)
 				}
 			})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -119,6 +119,30 @@ describe('validations tests', () => {
 		})
 	})
 
+	describe('storePerLimiter', () => {
+		it('should log an error if a store instance is used in two limiters', () => {
+			const store = { localKeys: true }
+
+			validations.storePerLimiter(store as Store)
+			expect(console.error).not.toBeCalled()
+			validations.storePerLimiter(store as Store)
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					code: 'ERR_ERL_STORE_REUSE',
+				}),
+			)
+		})
+
+		it('should not log an error if multiple store instances are used', () => {
+			const store1 = { localKeys: true }
+			const store2 = { localKeys: true }
+
+			validations.storePerLimiter(store1 as Store)
+			validations.storePerLimiter(store2 as Store)
+			expect(console.error).not.toBeCalled()
+		})
+	})
+
 	describe('singleCount', () => {
 		class TestExternalStore {
 			prefix?: string

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -119,13 +119,13 @@ describe('validations tests', () => {
 		})
 	})
 
-	describe('storePerLimiter', () => {
+	describe('unsharedStore', () => {
 		it('should log an error if a store instance is used in two limiters', () => {
 			const store = { localKeys: true }
 
-			validations.storePerLimiter(store as Store)
+			validations.unsharedStore(store as Store)
 			expect(console.error).not.toBeCalled()
-			validations.storePerLimiter(store as Store)
+			validations.unsharedStore(store as Store)
 			expect(console.error).toHaveBeenCalledWith(
 				expect.objectContaining({
 					code: 'ERR_ERL_STORE_REUSE',
@@ -137,8 +137,8 @@ describe('validations tests', () => {
 			const store1 = { localKeys: true }
 			const store2 = { localKeys: true }
 
-			validations.storePerLimiter(store1 as Store)
-			validations.storePerLimiter(store2 as Store)
+			validations.unsharedStore(store1 as Store)
+			validations.unsharedStore(store2 as Store)
 			expect(console.error).not.toBeCalled()
 		})
 	})


### PR DESCRIPTION
This checks for cases like https://github.com/express-rate-limit/express-rate-limit/discussions/457 where a single Store instance is shared across multiple rate limiter instances.

I saw there was an unrelated formatting change to the one test, so I updated my node modules and got a vulnerability warning, so I went ahead and fixed that too.

Example error messages:

> ValidationError: A Store instance must not be shared across multiple rate limiters. Create a new instance of MemoryStore for each limiter instead. See https://express-rate-limit.github.io/ERR_ERL_STORE_REUSE/ for more information.

Example for a store that doesn't have `localKeys` set:

> ValidationError: A Store instance must not be shared across multiple rate limiters. Create a new instance of ClusterMemoryStoreWorker (with a unique prefix) for each limiter instead. See https://express-rate-limit.github.io/ERR_ERL_STORE_REUSE/ for more information.

It feels a little wordy to me, but I think it gets the idea across.