### PR TITLE
fix: narrow scope of creationStack check to only stores with localKeys (e.g. MemoryStore)

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,7 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.3.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.2.1)
+## [7.3.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.3.1)
+
+### Fixed
+
+- Narrowed the scope of the `creationStack` validation check in order to prevent
+  false-positives
+
+## [7.3.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.3.0)
 
 ### Added
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -270,6 +270,15 @@ it is called at app initialization, not in response to each request:
 + app.use(rateLimitFactory()); // Works
 ```
 
+<Note>
+
+Starting with version 7.3.1, the scope of this check was narrowed to only
+trigger when using a MemoryStore, in order to prevent false-positives in
+advanced use-cases, such as a serving multiple websites from a single app and
+loading their configuration dynamically.
+
+</Note>
+
 Set `validate: {creationStack: false}` in the options to disable the check.
 
 ## Warnings

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -307,8 +307,8 @@ const rateLimit = (
 	const config = parseOptions(passedOptions ?? {})
 	const options = getOptionsFromConfig(config)
 
-	// The limiter shouldn't be created in response to a request
-	config.validations.creationStack()
+	// The limiter shouldn't be created in response to a request (usually)
+	config.validations.creationStack(config.store)
 	// The store instance shouldn't be shared across multiple limiters
 	config.validations.unsharedStore(config.store)
 

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -290,9 +290,13 @@ const validations = {
 	},
 
 	/**
-	 * Checks to see if the instance was created inside of a request handler, which would prevent it from working correctly.
+	 * Checks to see if the instance was created inside of a request handler, which would prevent it from working correctly, with the default memory store (or any other store with localKeys.)
 	 */
-	creationStack() {
+	creationStack(store: Store) {
+		if (!store.localKeys) {
+			return // Using an external store. This should be safe, even if not ideal.
+		}
+
 		const { stack } = new Error(
 			'express-rate-limit validation check (set options.validate.creationStack=false to disable)',
 		)

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -13,6 +13,7 @@ import express from 'express'
 import supertest from 'supertest'
 import { getValidations } from '../../source/validations.js'
 import type { Store } from '../../source/types'
+import { MemoryStore } from '../../source/index.js'
 
 describe('validations tests', () => {
 	let validations = getValidations(true)
@@ -360,10 +361,11 @@ describe('validations tests', () => {
 	})
 
 	describe('creationStack', () => {
-		it('should log an error if called in an express request handler', async () => {
+		it('should log an error if called in an express request handler with a memory store', async () => {
 			const app = express()
+			const store = new MemoryStore()
 			app.get('/', (request, response) => {
-				validations.creationStack()
+				validations.creationStack(store)
 				response.send('hello')
 			})
 			await supertest(app).get('/').expect('hello')
@@ -373,7 +375,14 @@ describe('validations tests', () => {
 			expect(console.warn).not.toBeCalled()
 		})
 		it('should not log an error if called elsewhere', async () => {
-			validations.creationStack()
+			const store = new MemoryStore()
+			validations.creationStack(store)
+			expect(console.error).not.toBeCalled()
+			expect(console.warn).not.toBeCalled()
+		})
+		it('should not log an error when used with an external store', () => {
+			const store: Store = { localKeys: false } as any
+			validations.creationStack(store)
 			expect(console.error).not.toBeCalled()
 			expect(console.warn).not.toBeCalled()
 		})


### PR DESCRIPTION
This disables the check unless using the MemoryStore or similar. It should prevent the false positive reported in https://github.com/express-rate-limit/express-rate-limit/issues/453#issuecomment-2148518565

FYI @WesCossick 