### PR TITLE
fix: print a different error for `creationStack` if the stores has `localKeys` set to false

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,7 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.3.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.2.1)
+## [7.3.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.3.1)
+
+### Fixed
+
+- Narrowed the scope of the `creationStack` validation check in order to prevent
+  false-positives
+
+## [7.3.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.3.0)
 
 ### Added
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -270,7 +270,10 @@ it is called at app initialization, not in response to each request:
 + app.use(rateLimitFactory()); // Works
 ```
 
-Set `validate: {creationStack: false}` in the options to disable the check.
+Set `validate: {creationStack: false}` in the options to disable the check, only
+if you are sure that the rate limiter is working as intended, and is not facing
+performance problems (that may be caused by repeated initialization of an
+external data store).
 
 ## Warnings
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -307,8 +307,8 @@ const rateLimit = (
 	const config = parseOptions(passedOptions ?? {})
 	const options = getOptionsFromConfig(config)
 
-	// The limiter shouldn't be created in response to a request
-	config.validations.creationStack()
+	// The limiter shouldn't be created in response to a request (usually)
+	config.validations.creationStack(config.store)
 	// The store instance shouldn't be shared across multiple limiters
 	config.validations.unsharedStore(config.store)
 


### PR DESCRIPTION
Supersedes #461, based on our discussion [here](https://github.com/express-rate-limit/express-rate-limit/pull/461#discussion_r1626940562).