### PR TITLE
feat: Added passOnStoreError to skip rate limitter if the store is not available (#447)

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.4.0)
+
+### Added
+
+- Added `passOnStoreError` option to allow a way to "fail open" in the event of
+  a backend error.
+
 ## [7.3.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.3.1)
 
 ### Fixed

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -215,6 +215,16 @@ is used.
 See [Data Stores](/reference/stores) for a list of avalliable stores and other
 information.
 
+## `passOnStoreError`
+
+By default, this is `false` and express-rate-limit will call the
+[express error handler](http://expressjs.com/en/guide/error-handling.html#error-handling)
+in the event of a store error. In other words, the default is to "fail closed"
+and block all requests in the event of a store.
+
+Set this to `true` to "fail open" allow the request(s) through without rate
+limiting. The error will be logged in this case.
+
 ## `keyGenerator`
 
 > `function`

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -220,7 +220,7 @@ information.
 By default, this is `false` and express-rate-limit will call the
 [express error handler](http://expressjs.com/en/guide/error-handling.html#error-handling)
 in the event of a store error. In other words, the default is to "fail closed"
-and block all requests in the event of a store.
+and block all requests if the datastore becomes unavailable.
 
 Set this to `true` to "fail open" allow the request(s) through without rate
 limiting. The error will be logged in this case.

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ The rate limiter comes with a built-in memory store, and supports a variety of
 ### Configuration
 
 All function options may be async. Click the name for additional info and
-default values. passOnStoreError
+default values.
 
 | Option                     | Type                             | Remarks                                                                                         |
 | -------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------- |

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ The rate limiter comes with a built-in memory store, and supports a variety of
 ### Configuration
 
 All function options may be async. Click the name for additional info and
-default values.
+default values. passOnStoreError
 
 | Option                     | Type                             | Remarks                                                                                         |
 | -------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------- |
@@ -55,6 +55,7 @@ default values.
 | [`legacyHeaders`]          | `boolean`                        | Enable the `X-Rate-Limit` header.                                                               |
 | [`standardHeaders`]        | `'draft-6'` \| `'draft-7'`       | Enable the `Ratelimit` header.                                                                  |
 | [`store`]                  | `Store`                          | Use a custom store to share hit counts across multiple nodes.                                   |
+| [`passOnStoreError`]       | `boolean`                        | Allow (`true`) or block (`false`, default) traffic if the store becomes unavailable.            |
 | [`keyGenerator`]           | `function`                       | Identify users (defaults to IP address).                                                        |
 | [`requestPropertyName`]    | `string`                         | Add rate limit info to the `req` object.                                                        |
 | [`skip`]                   | `function`                       | Return `true` to bypass the limiter for the given request.                                      |
@@ -126,6 +127,8 @@ MIT © [Nathan Friedly](http://nfriedly.com/),
 [`standardHeaders`]:
 	https://express-rate-limit.mintlify.app/reference/configuration#standardheaders
 [`store`]: https://express-rate-limit.mintlify.app/reference/configuration#store
+[`passOnStoreError`]:
+	https://express-rate-limit.mintlify.app/reference/configuration#passOnStoreError
 [`keyGenerator`]:
 	https://express-rate-limit.mintlify.app/reference/configuration#keygenerator
 [`requestPropertyName`]:

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -327,109 +327,18 @@ const rateLimit = (
 				return
 			}
 
+			// Create an augmented request
+			const augmentedRequest = request as AugmentedRequest
+			// Get a unique key for the client
+			const key = await config.keyGenerator(request, response)
+			// Increment the client's hit counter by one.
+
+			let totalHits = 0
+			let resetTime
 			try {
-				// Create an augmented request
-				const augmentedRequest = request as AugmentedRequest
-				// Get a unique key for the client
-				const key = await config.keyGenerator(request, response)
-				// Increment the client's hit counter by one.
-				const { totalHits, resetTime } = await config.store.increment(key)
-				// Make sure that -
-				// - the hit count is incremented only by one.
-				// - the returned hit count is a positive integer.
-				config.validations.positiveHits(totalHits)
-				config.validations.singleCount(request, config.store, key)
-
-				// Get the limit (max number of hits) for each client.
-				const retrieveLimit =
-					typeof config.limit === 'function'
-						? config.limit(request, response)
-						: config.limit
-				const limit = await retrieveLimit
-				config.validations.limit(limit)
-
-				// Define the rate limit info for the client.
-				const info: RateLimitInfo = {
-					limit,
-					used: totalHits,
-					remaining: Math.max(limit - totalHits, 0),
-					resetTime,
-				}
-
-				// Set the `current` property on the object, but hide it from iteration
-				// and `JSON.stringify`. See the `./types#RateLimitInfo` for details.
-				Object.defineProperty(info, 'current', {
-					configurable: false,
-					enumerable: false,
-					value: totalHits,
-				})
-
-				// Set the rate limit information on the augmented request object
-				augmentedRequest[config.requestPropertyName] = info
-
-				// Set the `X-RateLimit` headers on the response object if enabled.
-				if (config.legacyHeaders && !response.headersSent) {
-					setLegacyHeaders(response, info)
-				}
-
-				// Set the standardized `RateLimit-*` headers on the response object if
-				// enabled.
-				if (config.standardHeaders && !response.headersSent) {
-					if (config.standardHeaders === 'draft-6') {
-						setDraft6Headers(response, info, config.windowMs)
-					} else if (config.standardHeaders === 'draft-7') {
-						config.validations.headersResetTime(info.resetTime)
-						setDraft7Headers(response, info, config.windowMs)
-					}
-				}
-
-				// If we are to skip failed/successfull requests, decrement the
-				// counter accordingly once we know the status code of the request
-				if (config.skipFailedRequests || config.skipSuccessfulRequests) {
-					let decremented = false
-					const decrementKey = async () => {
-						if (!decremented) {
-							await config.store.decrement(key)
-							decremented = true
-						}
-					}
-
-					if (config.skipFailedRequests) {
-						response.on('finish', async () => {
-							if (!(await config.requestWasSuccessful(request, response)))
-								await decrementKey()
-						})
-						response.on('close', async () => {
-							if (!response.writableEnded) await decrementKey()
-						})
-						response.on('error', async () => {
-							await decrementKey()
-						})
-					}
-
-					if (config.skipSuccessfulRequests) {
-						response.on('finish', async () => {
-							if (await config.requestWasSuccessful(request, response))
-								await decrementKey()
-						})
-					}
-				}
-
-				// Disable the validations, since they should have run at least once by now.
-				config.validations.disable()
-
-				// If the client has exceeded their rate limit, set the Retry-After header
-				// and call the `handler` function.
-				if (totalHits > limit) {
-					if (config.legacyHeaders || config.standardHeaders) {
-						setRetryAfterHeader(response, info, config.windowMs)
-					}
-
-					config.handler(request, response, next, options)
-					return
-				}
-
-				next()
+				const incrementResult = await config.store.increment(key)
+				totalHits = incrementResult.totalHits
+				resetTime = incrementResult.resetTime
 			} catch (error) {
 				if (config.passOnStoreError) {
 					next()
@@ -437,6 +346,103 @@ const rateLimit = (
 					throw error
 				}
 			}
+
+			// Make sure that -
+			// - the hit count is incremented only by one.
+			// - the returned hit count is a positive integer.
+			config.validations.positiveHits(totalHits)
+			config.validations.singleCount(request, config.store, key)
+
+			// Get the limit (max number of hits) for each client.
+			const retrieveLimit =
+				typeof config.limit === 'function'
+					? config.limit(request, response)
+					: config.limit
+			const limit = await retrieveLimit
+			config.validations.limit(limit)
+
+			// Define the rate limit info for the client.
+			const info: RateLimitInfo = {
+				limit,
+				used: totalHits,
+				remaining: Math.max(limit - totalHits, 0),
+				resetTime,
+			}
+
+			// Set the `current` property on the object, but hide it from iteration
+			// and `JSON.stringify`. See the `./types#RateLimitInfo` for details.
+			Object.defineProperty(info, 'current', {
+				configurable: false,
+				enumerable: false,
+				value: totalHits,
+			})
+
+			// Set the rate limit information on the augmented request object
+			augmentedRequest[config.requestPropertyName] = info
+
+			// Set the `X-RateLimit` headers on the response object if enabled.
+			if (config.legacyHeaders && !response.headersSent) {
+				setLegacyHeaders(response, info)
+			}
+
+			// Set the standardized `RateLimit-*` headers on the response object if
+			// enabled.
+			if (config.standardHeaders && !response.headersSent) {
+				if (config.standardHeaders === 'draft-6') {
+					setDraft6Headers(response, info, config.windowMs)
+				} else if (config.standardHeaders === 'draft-7') {
+					config.validations.headersResetTime(info.resetTime)
+					setDraft7Headers(response, info, config.windowMs)
+				}
+			}
+
+			// If we are to skip failed/successfull requests, decrement the
+			// counter accordingly once we know the status code of the request
+			if (config.skipFailedRequests || config.skipSuccessfulRequests) {
+				let decremented = false
+				const decrementKey = async () => {
+					if (!decremented) {
+						await config.store.decrement(key)
+						decremented = true
+					}
+				}
+
+				if (config.skipFailedRequests) {
+					response.on('finish', async () => {
+						if (!(await config.requestWasSuccessful(request, response)))
+							await decrementKey()
+					})
+					response.on('close', async () => {
+						if (!response.writableEnded) await decrementKey()
+					})
+					response.on('error', async () => {
+						await decrementKey()
+					})
+				}
+
+				if (config.skipSuccessfulRequests) {
+					response.on('finish', async () => {
+						if (await config.requestWasSuccessful(request, response))
+							await decrementKey()
+					})
+				}
+			}
+
+			// Disable the validations, since they should have run at least once by now.
+			config.validations.disable()
+
+			// If the client has exceeded their rate limit, set the Retry-After header
+			// and call the `handler` function.
+			if (totalHits > limit) {
+				if (config.legacyHeaders || config.standardHeaders) {
+					setRetryAfterHeader(response, info, config.windowMs)
+				}
+
+				config.handler(request, response, next, options)
+				return
+			}
+
+			next()
 		},
 	)
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -329,10 +329,11 @@ const rateLimit = (
 
 			// Create an augmented request
 			const augmentedRequest = request as AugmentedRequest
+
 			// Get a unique key for the client
 			const key = await config.keyGenerator(request, response)
-			// Increment the client's hit counter by one.
 
+			// Increment the client's hit counter by one.
 			let totalHits = 0
 			let resetTime
 			try {

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -341,6 +341,10 @@ const rateLimit = (
 				resetTime = incrementResult.resetTime
 			} catch (error) {
 				if (config.passOnStoreError) {
+					console.error(
+						'express-rate-limit: error from store, allowing request without rate-limiting.',
+						error,
+					)
 					next()
 				} else {
 					throw error

--- a/source/types.ts
+++ b/source/types.ts
@@ -360,6 +360,11 @@ export type Options = {
 	 * be removed from the library in the foreseeable future.
 	 */
 	max?: number | ValueDeterminingMiddleware<number>
+
+	/**
+	 * If the Store generates an error, allow the request to pass.
+	 */
+	passOnStoreError: boolean
 }
 
 /**


### PR DESCRIPTION
I don't know why github closed #447 and won't let me re-open it, but I just gave up and recreated the PR here.

This PR:
* replaces #447 
* closes https://github.com/express-rate-limit/rate-limit-redis/pull/193
* fixes https://github.com/express-rate-limit/rate-limit-redis/issues/190
* fixes https://github.com/express-rate-limit/rate-limit-redis/issues/72

Original description below:

---

This PR adds the parameter passOnStoreError to allow requests if the store is not available.
For instance, if using Redis and the Redis server disconnects, the request will still pass.

This feature can be important for HA issues.
