### PR TITLE
fix: return after calling next() when passOnStoreError is used

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -347,9 +347,10 @@ const rateLimit = (
 						error,
 					)
 					next()
-				} else {
-					throw error
+					return
 				}
+
+				throw error
 			}
 
 			// Make sure that -

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -972,6 +972,7 @@ describe('middleware test', () => {
 	})
 
 	it('should pass if the store throws an error and passOnStoreError is true', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {})
 		const app = createServer(
 			rateLimit({
 				limit: 1,
@@ -980,5 +981,31 @@ describe('middleware test', () => {
 			}),
 		)
 		await request(app).get('/').expect(200)
+		expect(console.error).toHaveBeenCalledTimes(1)
+		expect(console.error).toHaveBeenCalledWith(
+			expect.stringContaining('allowing'),
+			expect.any(Error),
+		)
+	})
+
+	it('should should only call next once when passOnStoreError causes it to skip limiting', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {})
+		const limiter = rateLimit({
+			limit: 1,
+			store: new StoreThrowingErrors(),
+			passOnStoreError: true,
+			validate: false,
+		})
+		const request = {}
+		const response = {}
+		const next: NextFunction = jest.fn() as NextFunction
+		// eslint-disable-next-line @typescript-eslint/await-thenable
+		await limiter(request as Request, response as Response, next)
+		expect(next).toHaveBeenCalledTimes(1)
+		expect(console.error).toHaveBeenCalledTimes(1)
+		expect(console.error).toHaveBeenCalledWith(
+			expect.stringContaining('allowing'),
+			expect.any(Error),
+		)
 	})
 })


### PR DESCRIPTION
Fixes at least part of the issue reported at https://github.com/express-rate-limit/rate-limit-redis/issues/72#issuecomment-2389588306 and https://github.com/express-rate-limit/express-rate-limit/pull/471#issuecomment-2391091012

@modestaspruckus I know you said you tried this already and it didn't fix the issue, one thing that comes to mind is that we ship two copies of the code, one for commonjs (`require`) and one for esm (`import`) - it's possible that you edited one but your test used the other(?) Alternatively, it could be something to do with the store.

I think we should ship this fix regardless, because not returning was definitely wrong. Then you can try it out and if you're still experiencing the issue, we can dig in further.