### PR TITLE
Default to /56 subnet block for IPv6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,15 @@
 			"name": "express-rate-limit",
 			"version": "7.5.0",
 			"license": "MIT",
+			"dependencies": {
+				"ip": "2.0.1"
+			},
 			"devDependencies": {
 				"@express-rate-limit/prettier": "1.1.1",
 				"@express-rate-limit/tsconfig": "1.0.2",
 				"@jest/globals": "29.7.0",
 				"@types/express": "4.17.20",
+				"@types/ip": "1.1.3",
 				"@types/jest": "29.5.6",
 				"@types/node": "20.8.7",
 				"@types/supertest": "2.0.15",
@@ -2504,6 +2508,15 @@
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
 			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true
+		},
+		"node_modules/@types/ip": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
+			"integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
@@ -7975,6 +7988,11 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/ip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
 		},
 		"node_modules/ip-regex": {
 			"version": "4.3.0",
@@ -17795,6 +17813,15 @@
 			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true
 		},
+		"@types/ip": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
+			"integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -21781,6 +21808,11 @@
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
 			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
 			"dev": true
+		},
+		"ip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
 		},
 		"ip-regex": {
 			"version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"@express-rate-limit/tsconfig": "1.0.2",
 		"@jest/globals": "29.7.0",
 		"@types/express": "4.17.20",
+		"@types/ip": "1.1.3",
 		"@types/jest": "29.5.6",
 		"@types/node": "20.8.7",
 		"@types/supertest": "2.0.15",
@@ -129,5 +130,8 @@
 	"lint-staged": {
 		"{source,test}/**/*.ts": "xo --fix",
 		"**/*.{json,yaml,md}": "prettier --write "
+	},
+	"dependencies": {
+		"ip": "2.0.1"
 	}
 }

--- a/source/headers.ts
+++ b/source/headers.ts
@@ -37,7 +37,7 @@ const getResetSeconds = (
 /**
  * Returns the hash of the identifier, truncated to 12 bytes, and then converted
  * to base64 so that it can be used as a 16 byte partition key. The 16-byte limit
- * is arbitrary, and folllows from the examples given in the 8th draft.
+ * is arbitrary, and follows from the examples given in the 8th draft.
  *
  * @param key {string} - The identifier to hash.
  */

--- a/source/index.ts
+++ b/source/index.ts
@@ -8,6 +8,8 @@ export * from './types.js'
 // the default export does not work (see https://github.com/nfriedly/express-rate-limit/issues/280)
 export { default, default as rateLimit } from './lib.js'
 
+export { ipKeyGenerator } from './ip-key-generator.js'
+
 // Export the memory store in case someone wants to use or extend it
 // (see https://github.com/nfriedly/express-rate-limit/issues/289)
 export { default as MemoryStore } from './memory-store.js'

--- a/source/ip-key-generator.ts
+++ b/source/ip-key-generator.ts
@@ -1,0 +1,25 @@
+import { isIPv6 } from 'node:net'
+import iptools from 'ip'
+
+/**
+ * Returns the IP address itself for IPv4, or a CIDR-notation subnet for IPv6 (e.g. '1234:abcd::/64')
+ *
+ * If you write a custom keyGenerator that allows a fallback to IP address for unauthenticated users, return ipKeyGenerator(req.ip) rather than just req.ip.
+ *
+ * See [Options.ipv6Subnet] for more info.
+ *
+ * @param ip request.ip
+ * @param [ipv6Subnet=64] subnet mask for IPv6 addresses
+ */
+export function ipKeyGenerator(ip: string, ipv6Subnet: number | false = 64) {
+	if (ipv6Subnet && isIPv6(ip)) {
+		// For IPv6, return the network address of the subnet in CIDR format
+		return `${iptools.mask(
+			ip,
+			iptools.fromPrefixLen(ipv6Subnet),
+		)}/${ipv6Subnet}`
+	}
+
+	// For IPv4, just return the IP address itself
+	return ip
+}

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -3,7 +3,11 @@
 
 import { isIP } from 'node:net'
 import type { Request } from 'express'
-import type { Store, EnabledValidations } from './types.js'
+import type {
+	Store,
+	EnabledValidations,
+	ValueDeterminingMiddleware,
+} from './types.js'
 import { SUPPORTED_DRAFT_VERSIONS } from './headers.js'
 
 /**
@@ -31,6 +35,11 @@ class ValidationError extends Error {
 		this.help = url
 	}
 }
+
+/**
+ * A warning logged for things that are unlikely but could be correct.
+ */
+class ValidationWarning extends ValidationError {}
 
 /**
  * A warning logged when the configuration used will/has been changed by a
@@ -342,6 +351,36 @@ const validations = {
 			)
 		}
 	},
+
+	ipv6Subnet(ipv6Subnet?: any) {
+		if (ipv6Subnet === false) {
+			return // Explicitly disabled
+		}
+
+		if (!Number.isInteger(ipv6Subnet) || ipv6Subnet < 32 || ipv6Subnet > 64) {
+			throw new ValidationError(
+				'ERR_ERL_INVALID_IPV6_SUBNET',
+				`Unexpected ipv6Subnet value: ${ipv6Subnet}. Expected an integer between 32 and 64 (usually 48-64).`,
+			)
+		}
+	},
+
+	keyGeneratorIpFallback(keyGenerator?: ValueDeterminingMiddleware<string>) {
+		if (!keyGenerator) {
+			return
+		}
+
+		const src = keyGenerator.toString()
+		if (
+			(src.includes('req.ip') || src.includes('request.ip')) &&
+			!src.includes('ipKeyGenerator')
+		) {
+			throw new ValidationWarning(
+				'WRN_ERL_KEY_GEN_IPV6',
+				`Custom keyGenerator appears to use request IP without calling the ipKeyGenerator helper function for IPv6 addresses. This could allow IPv6 users to bypass limits.`,
+			)
+		}
+	},
 }
 
 export type Validations = typeof validations
@@ -391,7 +430,11 @@ export const getValidations = (
 						args,
 					)
 				} catch (error: any) {
-					if (error instanceof ChangeWarning) console.warn(error)
+					if (
+						error instanceof ChangeWarning ||
+						error instanceof ValidationWarning
+					)
+						console.warn(error)
 					else console.error(error)
 				}
 			}

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -82,10 +82,11 @@ describe('headers test', () => {
 				windowMs: 2 * 60 * 60 * 1000,
 				limit: 5,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'foo', // Pk param is generated from this
 			}),
 		)
 
-		const policy = '"5-in-2hrs"; q=5; w=7200; pk=:M2U0OGVmOWQyMmUw:'
+		const policy = '"5-in-2hrs"; q=5; w=7200; pk=:MmMyNmI0NmI2OGZm:'
 		const limit = '"5-in-2hrs"; r=4; t=7200'
 
 		await request(app)
@@ -101,17 +102,19 @@ describe('headers test', () => {
 				windowMs: 60 * 1000,
 				limit: 5,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'foo', // Pk param is generated from this
 			}),
 			rateLimit({
 				windowMs: 2 * 24 * 60 * 60 * 1000,
 				limit: 8,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'bar', // Alternate pk
 			}),
 		])
 
 		const policies = [
-			'"5-in-1min"; q=5; w=60; pk=:M2U0OGVmOWQyMmUw:',
-			'"8-in-2days"; q=8; w=172800; pk=:M2U0OGVmOWQyMmUw:',
+			'"5-in-1min"; q=5; w=60; pk=:MmMyNmI0NmI2OGZm:',
+			'"8-in-2days"; q=8; w=172800; pk=:ZmNkZTJiMmVkYmE1:',
 		]
 		const limits = ['"5-in-1min"; r=4; t=60', '"8-in-2days"; r=7; t=172800']
 
@@ -129,6 +132,7 @@ describe('headers test', () => {
 				windowMs: 2 * 60 * 60 * 1000,
 				limit: 5,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'foo', // Pk param is generated from this
 			}),
 		)
 
@@ -136,7 +140,7 @@ describe('headers test', () => {
 			.get('/')
 			.expect(
 				'ratelimit-policy',
-				'"keep-kalm"; q=5; w=7200; pk=:M2U0OGVmOWQyMmUw:',
+				'"keep-kalm"; q=5; w=7200; pk=:MmMyNmI0NmI2OGZm:',
 			)
 			.expect('ratelimit', '"keep-kalm"; r=4; t=7200')
 			.expect(200, 'Hi there!')
@@ -164,6 +168,7 @@ describe('headers test', () => {
 			used: 1,
 			remaining: 4,
 			resetTime: new Date(),
+			key: 'foo',
 		}
 		const windowMs = 60 * 1000
 

--- a/test/library/ip-key-generator-test.ts
+++ b/test/library/ip-key-generator-test.ts
@@ -1,0 +1,36 @@
+import { ipKeyGenerator } from '../../source/index.js'
+
+describe('ipKeyGenerator', () => {
+	it('should return an IPv4 address unchanged', () => {
+		expect(ipKeyGenerator('1.2.3.4')).toBe('1.2.3.4')
+		expect(ipKeyGenerator('1.2.3.4', 16)).toBe('1.2.3.4')
+	})
+
+	it('should return an IPv6 address unchanged with ipv6Subnet set to false', () => {
+		expect(
+			ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', false),
+		).toBe('0123:4567:89ab:cdef:0123:4567:89ab:cdef')
+	})
+
+	it('should apply a default /64 netmask to an IPv6 address', () => {
+		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef')).toBe(
+			'123:4567:89ab:cdef::/64',
+		)
+	})
+
+	it('should apply a /63 netmask to an IPv6 address', () => {
+		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', 63)).toBe(
+			'123:4567:89ab:cdee::/63',
+		)
+	})
+
+	it('should accept abbreviated IPv6 addresses', () => {
+		expect(ipKeyGenerator('123:ABC::89')).toBe('123:abc::/64')
+	})
+
+	it('should return an IPv6 address normalized but otherwise unchanged with a /128 netmask', () => {
+		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', 128)).toBe(
+			'123:4567:89ab:cdef:123:4567:89ab:cdef/128',
+		)
+	})
+})


### PR DESCRIPTION
This enables blocking of entire subnets for IPv6 with a somewhat aggressive default block of /56.

It also adds a helper function that can be used as a fallback in custom keyGenerators, and a couple of new validation checks.

Todo:
* [ ] Readme example
* [ ] Readme config option
* [ ] Docs for new config option
* [ ] Docs for new error codes
* [ ] Redirects for new error codes (different repo)

I also added the key to the `key` to the `RateLimitInfo` object since it's no longer quite as obvious.