### PR TITLE
IPv6 subnet backport to 7.x 

### DIFF
--- a/docs/guides/creating-a-store.mdx
+++ b/docs/guides/creating-a-store.mdx
@@ -112,8 +112,9 @@ type SomeStoreOptions = {
 
 /**
  * A `Store` that stores the hit count for each client.
+ *
+ * @public
  */
-@public
 class SomeStore implements Store {
 	/**
 	 * Some store-specific parameter.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -32,6 +32,7 @@
 			"pages": [
 				"reference/configuration",
 				"reference/stores",
+				"reference/helpers",
 				"reference/instance-api",
 				"reference/request-api",
 				"reference/error-codes",
@@ -86,6 +87,18 @@
 		{
 			"source": "/errors/err_erl_unknown_validation",
 			"destination": "/reference/error-codes#err-erl-unknown-validation"
+		},
+		{
+			"source": "/errors/err_erl_ipv6_subnet",
+			"destination": "/reference/error-codes#err-erl-ipv6-subnet"
+		},
+		{
+			"source": "/errors/err_erl_ipv6subnet_or_keygenerator",
+			"destination": "/reference/error-codes#err-erl-ipv6subnet-or-keygenerator"
+		},
+		{
+			"source": "/errors/err_erl_key_gen_ipv6",
+			"destination": "/reference/error-codes#err-erl-key-gen-ipv6"
 		},
 		{
 			"source": "/errors/wrn_erl_max_zero",

--- a/docs/quickstart/usage.mdx
+++ b/docs/quickstart/usage.mdx
@@ -44,6 +44,7 @@ const limiter = rateLimit({
 	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
 	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+	ipv6Subnet: 56, // Set to 60 or 64 to be less aggressive, or 52 or 48 to be more aggressive
 })
 ```
 

--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.6.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.6.0)
+
+Note: There are reasonable arguments for why this release could have been
+considered a semver-patch (because this is probably the behavior it should have
+had all along) or, alternatively a semver-major change (because of the /56
+default value). But, we chose semver-patch because a) it _is_ a new feature and
+b) we want to be able to backport it to earlier major versions.
+
+### Fixed
+
+- Fixed a vulnerability where IPv6 users could bypass rate limiting by iterating
+  through multiple IP addresses in their ISP-assigned subnet.
+
+### Added
+
+- `ipv6Subnet` configuration option used by the default `keyGenerator`, defaults
+  to `56`
+- `ipKeyGenerator(ip, ipv6Subnet)` helper method to apply the desired subnet to
+  IPv6 addresses (returns IPv4 unchanged)
+- `ipv6Subnet` validation check on above configuration option's value (allowed
+  range is 32-64)
+- `ipv6SubnetOrKeyGenerator` validation check to warn of an incompatible
+  combination of `ipv6Subnet` and `keyGenerator` settings.
+- `keyGeneratorIpFallback` validation check on custom `keyGenerator`s to ensure
+  they're using `ipKeyGenerator` if they reference `req.ip` or `request.ip`
+
 ## [7.5.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.5.1)
 
 ### Changed
@@ -24,7 +50,7 @@ and this project adheres to
 
 - Implemented the combined `RateLimit` header according to the eighth draft of
   the
-  [IETF RateLimit header specificiation](https://github.com/ietf-wg-httpapi/ratelimit-headers).
+  [IETF RateLimit header specification](https://github.com/ietf-wg-httpapi/ratelimit-headers).
   Enable by setting `standardHeaders: 'draft-8'`.
 - Added a new `identifier` option, used as the name for the quota policy in the
   `draft-8` headers.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -280,12 +280,19 @@ username, or API Key.
 Should be a (sync/async) function that accepts the Express `request` and
 `response` objects and then returns a string.
 
-By default, the client's IP address is used:
+By default, the client's IP address is used with the
+[`ipKeyGenerator`](./helpers#ipkeygenerator) method to apply the configured
+[`ipv6Subnet`](#ipv6subnet) to IPv6 addresses.
+
+Custom `keyGenerator`s that fall back to IP addresses should use the provided
+[`ipKeyGenerator`](./helpers#ipkeygenerator) method and a chosen subnet for IPv6
+addresses (see [ipv6Subnet](#ipv6subnet) discussion below.)
 
 ```ts
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit'
 const limiter = rateLimit({
 	// ...
-	keyGenerator: (req, res) => req.ip,
+	keyGenerator: (req, res) => ipKeyGenerator(req.ip),
 })
 ```
 
@@ -296,6 +303,76 @@ rate limiter. This could be combined with a second instance of
 `express-rate-limit` to have both global and per-user limits.
 
 </Note>
+
+## `ipv6Subnet`
+
+> `number` (32-64) | `function` | `false`
+
+IPv6 subnet mask applied to IPv6 addresses in the default
+[`keyGenerator`](#keygenerator).
+
+Generally, ISPs that support IPv6 give each of their customers a range of IPv6
+addresses via a subnet mask, whereas they usually provide only a single IPv4
+address per customer. A malicious user could iterate through their range of IPv6
+addresses and bypass simple IP-based rate limiting. This setting counteracts
+that by allowing the rate-limiter to block an entire range of IPv6 addresses at
+once.
+
+It's generally not possible to know what subnet an ISP has assigned to a user,
+so we have to make an educuated guess.
+
+The default value is 56, corresponding to a /56 subnet.
+
+The valid range is 1-128, but typically ISPs assign subnets in the range of
+32-64, with 64 being the most common. The validation check (which can be
+disabled) will warn for values outside the 32-64 range.
+
+Smaller values block larger ranges of IPs at once. 56 is a moderately aggressive
+default. It may be increased to if users are being incorrectly blocked (try 60
+or 64), or decreased if you are seeing evidence of abuse.
+
+64, 60 ([Comcast](https://news.ycombinator.com/item?id=44228908)), 56, and 48
+are all common values used by various ISPs.
+
+The option may also be set to a function that returns the value if you want to
+apply different subnets to different users. (It's not always possible to know
+what subnet a given user has, but you could make an educuated guess based on
+their ISP - see the example below.)
+
+Set to false to disable and always use the IP without masking.
+
+This example uses the node.js built-in
+[`net.BlockList`](https://nodejs.org/api/net.html#class-netblocklist) to apply
+different subnets to different IP ranges:
+
+```js
+import { BlockList } from 'node:net'
+// or
+// const { BlockList } = require('node:net')
+
+// Comcast defaults to /64 but allows customers to request /60
+// (note that this is a non-exhaustive list, there are many more)
+const networks60 = new BlockList()
+networks60.addSubnet('2a0c:93c0:10::', 44, 'ipv6')
+networks60.addSubnet('2a0c:93c0:6000::', 48, 'ipv6')
+networks60.addSubnet('2a0c:93c0:6002::', 48, 'ipv6')
+
+// AWS allows customers to request up to a /44!
+// (the full list is at https://ip-ranges.amazonaws.com/ip-ranges.json)
+const networks44 = new BlockList()
+networks44.addSubnet('2600:1f69:7400::', 40, 'ipv6')
+
+app.use(
+	rateLimit({
+		ipv6Subnet: function (req, res) {
+			if (networks60.check(req.ip, 'ipv6')) return 60
+			if (networks44.check(req.ip, 'ipv6')) return 44
+			return 56 // fallback
+		},
+		// ...
+	}),
+)
+```
 
 ## `requestPropertyName`
 
@@ -427,13 +504,15 @@ Supported validations are:
 - [positiveHits](/reference/error-codes#err-erl-invalid-hits)
 - [unsharedStore](/reference/error-codes#err-erl-store-reuse)
 - [singleCount](/reference/error-codes#err-erl-double-count)
-- [limit](/reference/error-codes#wrn-erl-max-zero) (Note: the `limit` option was
-  renamed to `max`, but the validation name did not change.)
+- [limit](/reference/error-codes#wrn-erl-max-zero)
 - [draftPolliHeaders](/reference/error-codes#wrn-erl-deprecated-draft-polli-headers)
 - [onLimitReached](/reference/error-codes#wrn-erl-deprecated-on-limit-reached)
 - [headersDraftVersion](/reference/error-codes#err-erl-headers-unsupported-draft-version)
 - [headersResetTime](/reference/error-codes#err-erl-headers-no-reset)
 - [creationStack](/reference/error-codes#err-erl-created-in-request-handler)
 - [validationsConfig](/reference/error-codes#err-erl-unknown-validation)
+- [ipv6Subnet](/reference/error-codes#err-erl-ipv6-subnet)
+- [ipv6SubnetOrKeyGenerator](/reference/error-codes#err-erl-ipv6subnet-or-keygenerator)
+- [keyGeneratorIpFallback](/reference/error-codes#err-erl-key-gen-ipv6)
 
 Defaults to `true`.

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -279,8 +279,8 @@ it is called at app initialization, not in response to each request:
   	return rateLimit({/*...*/});
   }
 
-- app.use(rateLimitFactory); // Broken
-+ app.use(rateLimitFactory()); // Works
+- app.use(rateLimitFactory); // broken
++ app.use(rateLimitFactory()); // works
 ```
 
 In certain advanced use cases, such as serving multiple websites from a single
@@ -291,6 +291,91 @@ it's first usage to avoid repeating the initialization cost and any background
 work the store may require.
 
 Set `validate: {creationStack: false}` in the options to disable the check.
+
+### `ERR_ERL_IPV6_SUBNET`
+
+> Added in `7.6.0`.
+
+The [`ipv6Subnet`](./configuration#ipv6subnet) option must be set to an integer
+in the range of 1 to 128 (inclusive), or a function that returns such an
+integer. Set it to `false` to disable the subnet masking.
+
+_However_ this validation check is more restrictive in that it only allows for a
+number in the more common range of 32 to 64. Subnet values less than /32 will
+block a large portion of the internet, and on the other side, ISPs very rarely
+give out subnets larger than /64 because certain IPv6 features (SLAAC) depend on
+it. Disable this check if you are confident that larger or smaller subnets are
+correct for your use-case.
+
+Set `validate: {ipv6Subnet: false}` in the options to disable the check.
+
+### `ERR_ERL_IPV6SUBNET_OR_KEYGENERATOR`
+
+> Added in `7.6.0`.
+
+The [`ipv6Subnet`](./configuration#ipv6subnet) and
+[`keyGenerator`](./configuration#keygenerator) options are mutually exclusive. A
+custom `keyGenerator` function does respect the value of the `ipv6Subnet`
+option - only the default `keyGenerator` makes use of it.
+
+When using a custom `keyGenerator`, the `ipv6Subnet` should instead be set or
+calculated inside the `keyGenerator` and passed as a second parameter to the
+[`ipKeyGenerator`](./helpers#ipkeygenerator) helper function like so:
+
+```js
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit
+
+const limiter = rateLimit({
+	// ...
+	keyGenerator: (req, res) => {
+ 		if (req.query.apiKey) return req.query.apiKey
+
+ 		const ipv6Subnet = 64 // calculate or set a fixed value here
+		return ipKeyGenerator(req.ip, ipv6Subnet)
+	}
+})
+```
+
+Set `validate: {ipv6SubnetOrKeyGenerator: false}` in the options to disable the
+check.
+
+### `ERR_ERL_KEY_GEN_IPV6`
+
+> Added in `7.6.0`.
+
+This error indicates that your custom
+[`keyGenerator`](./configuration#keygenerator) appears to have a vulnerability
+where IPv6 users can easily bypass rate-limiting by rotating through their
+available IP addresses. (See [`ipv6Subnet`](./configuration#ipv6subnet) setting
+for more info.)
+
+Correct this error by wrapping your use of `req.ip` with the
+[`ipKeyGenerator`](./helpers#ipkeygenerator) helper function like so:
+
+```js
+ import { rateLimit, ipKeyGenerator } from 'express-rate-limit
+
+ const limiter = rateLimit({
+ 	// ...
+ 	keyGenerator: (req, res) => {
+ 		// Use API key (or some other identifier) for authenticated users
+ 		if (req.query.apiKey) return req.query.apiKey
+
+ 		// fallback to IP for unauthenticated users
+		// return req.ip // vulnerable
+		return ipKeyGenerator(req.ip) // better
+	}
+ })
+```
+
+(See the [example above](#err-erl-ipv6subnet-or-keygenerator) for a custom
+`ipv6Subnet`.)
+
+Disable this check if your `keyGenerator` already takes IPv6 subnets into
+account.
+
+Set `validate: {keyGeneratorIpFallback: false}` in the options to disable the
+check.
 
 ## Warnings
 

--- a/docs/reference/helpers.mdx
+++ b/docs/reference/helpers.mdx
@@ -1,0 +1,41 @@
+---
+title: 'Helpers'
+icon: 'puzzle-piece'
+---
+
+## `ipKeyGenerator(ip, ipv6Subnet=56)`
+
+**Params:**
+
+- `ip` (string) An IPv4 or IPv6 IP address
+- `ipv6Subnet` (number|false) Subnet mask to apply to IPv6 addresses. Valid
+  range is 1-120, recommend range is 48-64.
+
+**Returns:** (string) IPv4 address unchanged, or IPv6 network address in CIDR
+notation. (Unless second parameter is `false`, then IPv6 is also returned
+unchanged).
+
+This method is used by the default
+[`keyGenerator`](./configuration#keygenerator) to apply the configured
+[`ipv6Subnet`](./configuration#ipv6subnet), in order to properly rate-limit IPv6
+users.
+
+When using a custom [`keyGenerator`](./configuration#keygenerator) that uses the
+user's IP for rate-limiting (even as a fallback), return the result of this
+method rather than the IP address itself.
+
+```ts
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit
+const limiter = rateLimit({
+	// ...
+	keyGenerator: (req, res) => {
+        // use userID for authenticated users
+        if (userIsAuthenticate(req)) {
+            return req.userId
+        }
+        // fall back to IP address for unauthenticated users
+        // use ipKeyGenerator to apply a /56 subnet to IPv6 users (IPv4 returned unchanged)
+        return ipKeyGenerator(req.ip, 56)
+    },
+})
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,15 @@
 			"name": "express-rate-limit",
 			"version": "7.5.1",
 			"license": "MIT",
+			"dependencies": {
+				"ip": "2.0.1"
+			},
 			"devDependencies": {
 				"@express-rate-limit/prettier": "1.1.1",
 				"@express-rate-limit/tsconfig": "1.0.2",
 				"@jest/globals": "29.7.0",
 				"@types/express": "4.17.20",
+				"@types/ip": "1.1.3",
 				"@types/jest": "29.5.6",
 				"@types/node": "20.8.7",
 				"@types/supertest": "2.0.15",
@@ -2504,6 +2508,15 @@
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
 			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true
+		},
+		"node_modules/@types/ip": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
+			"integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
@@ -7975,6 +7988,11 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/ip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
 		},
 		"node_modules/ip-regex": {
 			"version": "4.3.0",
@@ -17795,6 +17813,15 @@
 			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true
 		},
+		"@types/ip": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
+			"integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -21781,6 +21808,11 @@
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
 			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
 			"dev": true
+		},
+		"ip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
 		},
 		"ip-regex": {
 			"version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
 	},
 	"scripts": {
 		"clean": "del-cli dist/ coverage/ *.log *.tmp *.bak *.tgz",
-		"build:cjs": "esbuild --platform=node --bundle --target=es2022 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = rateLimit; module.exports.default = rateLimit; module.exports.rateLimit = rateLimit; module.exports.MemoryStore = MemoryStore;\" source/index.ts",
-		"build:esm": "esbuild --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
+		"build:cjs": "esbuild --packages=external --platform=node --bundle --target=es2022 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = rateLimit; module.exports.default = rateLimit; module.exports.rateLimit = rateLimit; module.exports.MemoryStore = MemoryStore;\" source/index.ts",
+		"build:esm": "esbuild --packages=external --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
 		"build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts dist/index.d.mts",
 		"compile": "run-s clean build:*",
 		"docs": "cd docs && mintlify dev",
@@ -81,6 +81,7 @@
 		"@express-rate-limit/tsconfig": "1.0.2",
 		"@jest/globals": "29.7.0",
 		"@types/express": "4.17.20",
+		"@types/ip": "1.1.3",
 		"@types/jest": "29.5.6",
 		"@types/node": "20.8.7",
 		"@types/supertest": "2.0.15",
@@ -129,5 +130,8 @@
 	"lint-staged": {
 		"{source,test}/**/*.ts": "xo --fix",
 		"**/*.{json,yaml,md}": "prettier --write "
+	},
+	"dependencies": {
+		"ip": "2.0.1"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -133,9 +133,11 @@ MIT © [Nathan Friedly](http://nfriedly.com/),
 	https://express-rate-limit.mintlify.app/reference/configuration#identifier
 [`store`]: https://express-rate-limit.mintlify.app/reference/configuration#store
 [`passOnStoreError`]:
-	https://express-rate-limit.mintlify.app/reference/configuration#passOnStoreError
+	https://express-rate-limit.mintlify.app/reference/configuration#passonstoreerror
 [`keyGenerator`]:
 	https://express-rate-limit.mintlify.app/reference/configuration#keygenerator
+[`ipv6Subnet`]:
+	https://express-rate-limit.mintlify.app/reference/configuration#ipv6subnet
 [`requestPropertyName`]:
 	https://express-rate-limit.mintlify.app/reference/configuration#requestpropertyname
 [`skip`]: https://express-rate-limit.mintlify.app/reference/configuration#skip

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ const limiter = rateLimit({
 	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes).
 	standardHeaders: 'draft-8', // draft-6: `RateLimit-*` headers; draft-7 & draft-8: combined `RateLimit` header
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers.
+	ipv6Subnet: 56, // Set to 60 or 64 to be less aggressive, or 52 or 48 to be more aggressive
 	// store: ... , // Redis, Memcached, etc. See below.
 })
 
@@ -58,6 +59,7 @@ default values.
 | [`store`]                  | `Store`                                   | Use a custom store to share hit counts across multiple nodes.                                   |
 | [`passOnStoreError`]       | `boolean`                                 | Allow (`true`) or block (`false`, default) traffic if the store becomes unavailable.            |
 | [`keyGenerator`]           | `function`                                | Identify users (defaults to IP address).                                                        |
+| [`ipv6Subnet`]             | `number` (32-64) \| `function` \| `false` | How many bits of IPv6 addresses to use in default `keyGenerator`                                |
 | [`requestPropertyName`]    | `string`                                  | Add rate limit info to the `req` object.                                                        |
 | [`skip`]                   | `function`                                | Return `true` to bypass the limiter for the given request.                                      |
 | [`skipSuccessfulRequests`] | `boolean`                                 | Uncount 1xx/2xx/3xx responses.                                                                  |

--- a/source/headers.ts
+++ b/source/headers.ts
@@ -41,7 +41,7 @@ const getResetSeconds = (
 /**
  * Returns the hash of the identifier, truncated to 12 bytes, and then converted
  * to base64 so that it can be used as a 16 byte partition key. The 16-byte limit
- * is arbitrary, and folllows from the examples given in the 8th draft.
+ * is arbitrary, and follows from the examples given in the 8th draft.
  *
  * @param key {string} - The identifier to hash.
  */

--- a/source/index.ts
+++ b/source/index.ts
@@ -8,6 +8,8 @@ export * from './types.js'
 // the default export does not work (see https://github.com/nfriedly/express-rate-limit/issues/280)
 export { default, default as rateLimit } from './lib.js'
 
+export { ipKeyGenerator } from './ip-key-generator.js'
+
 // Export the memory store in case someone wants to use or extend it
 // (see https://github.com/nfriedly/express-rate-limit/issues/289)
 export { default as MemoryStore } from './memory-store.js'

--- a/source/ip-key-generator.ts
+++ b/source/ip-key-generator.ts
@@ -16,7 +16,7 @@ import iptools from 'ip'
  *
  * @public
  */
-export function ipKeyGenerator(ip: string, ipv6Subnet: number | false = 56) {
+export function ipKeyGenerator(ip: string, ipv6Subnet: number | false = 64) {
 	if (ipv6Subnet && isIPv6(ip)) {
 		// For IPv6, return the network address of the subnet in CIDR format
 		return `${iptools.mask(

--- a/source/ip-key-generator.ts
+++ b/source/ip-key-generator.ts
@@ -1,0 +1,30 @@
+import { isIPv6 } from 'node:net'
+import iptools from 'ip'
+
+/**
+ * Returns the IP address itself for IPv4, or a CIDR-notation subnet for IPv6.
+ *
+ * If you write a custom keyGenerator that allows a fallback to IP address for
+ * unauthenticated users, return ipKeyGenerator(req.ip) rather than just req.ip.
+ *
+ * For more infomration, {@see Options.ipv6Subnet}.
+ *
+ * @param ip {string} - The IP address to process, usually request.ip.
+ * @param ipv6Subnet {number | false} - The subnet mask for IPv6 addresses.
+ *
+ * @returns {string} - The key generated from the IP address
+ *
+ * @public
+ */
+export function ipKeyGenerator(ip: string, ipv6Subnet: number | false = 56) {
+	if (ipv6Subnet && isIPv6(ip)) {
+		// For IPv6, return the network address of the subnet in CIDR format
+		return `${iptools.mask(
+			ip,
+			iptools.fromPrefixLen(ipv6Subnet),
+		)}/${ipv6Subnet}`
+	}
+
+	// For IPv4, just return the IP address itself
+	return ip
+}

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -231,7 +231,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 			// Note: eslint thinks the ! is unnecessary but dts-bundle-generator disagrees
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 			const ip: string = request.ip!
-			let subnet: number | false = 56
+			let subnet: number | false = 64
 
 			if (isIPv6(ip)) {
 				// Apply subnet to ignore the bits that he end-user controls and rate-limit on only the bits their ISP controls
@@ -247,7 +247,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 
 			return ipKeyGenerator(ip, subnet)
 		},
-		ipv6Subnet: 56,
+		ipv6Subnet: 64,
 		async handler(
 			request: Request,
 			response: Response,

--- a/source/types.ts
+++ b/source/types.ts
@@ -317,7 +317,7 @@ export type Options = {
 	/**
 	 * IPv6 subnet mask applied to IPv6 addresses in the default keyGenerator.
 	 *
-	 * Default is 56. The valid range is technically 1-128 but the value should
+	 * Default is 64 in this version, 56 in 8.0.0 and newer. The valid range is technically 1-128 but the value should
 	 * generally be in the 32-64 range.
 	 *
 	 * Smaller numbers are more aggressive, larger numbers are more lenient. Try

--- a/source/types.ts
+++ b/source/types.ts
@@ -207,7 +207,8 @@ export type Store = {
 	/**
 	 * Optional value that the store prepends to keys
 	 *
-	 * Used by the double-count check to avoid false-positives when a key is counted twice, but with different prefixes
+	 * Used by the double-count check to avoid false-positives when a key is counted
+	 * twice, but with different prefixes.
 	 */
 	prefix?: string
 }
@@ -314,6 +315,32 @@ export type Options = {
 	keyGenerator: ValueDeterminingMiddleware<string>
 
 	/**
+	 * IPv6 subnet mask applied to IPv6 addresses in the default keyGenerator.
+	 *
+	 * Default is 56. The valid range is technically 1-128 but the value should
+	 * generally be in the 32-64 range.
+	 *
+	 * Smaller numbers are more aggressive, larger numbers are more lenient. Try
+	 * bumping to 60 or 64 if you see evidence of users being blocked incorrectly.
+	 *
+	 * May also be set to a function that returns a number based on the request.
+	 *
+	 * See the documentation for more info:
+	 * https://express-rate-limit.mintlify.app/reference/configuration#ipv6subnet.
+	 */
+	ipv6Subnet:
+		| 64 // A few common values, followed by number as a catch-all
+		| 60 // Apparently comcast allows customers to request up to a /60, which is effectively 16 /64s
+		| 56
+		| 52
+		| 50
+		| 48
+		| 32
+		| number // TODO: figure out how to do a "range type" to replace `number` with "1-128". (The validator limits to 32-64, but typescript should probably allow the whole range.)
+		| ValueDeterminingMiddleware<number>
+		| false
+
+	/**
 	 * Express request handler that sends back a response when a client is
 	 * rate-limited.
 	 *
@@ -330,7 +357,7 @@ export type Options = {
 	skip: ValueDeterminingMiddleware<boolean>
 
 	/**
-	 * Method to determine whether or not the request counts as 'succesful'. Used
+	 * Method to determine whether or not the request counts as 'successful'. Used
 	 * when either `skipSuccessfulRequests` or `skipFailedRequests` is set to true.
 	 *
 	 * By default, requests with a response status code less than 400 are considered
@@ -393,6 +420,7 @@ export type RateLimitInfo = {
 	used: number
 	remaining: number
 	resetTime: Date | undefined
+	key: string // IP address, etc.
 
 	/**
 	 * NOTE: The `current` field is deprecated and renamed to `used`. The library

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -1,0 +1,31 @@
+// /source/utils.ts
+// Utility functions used multiple times in the code
+
+/**
+ *
+ * Remove any properties where their value is set to undefined. This avoids overwriting defaults
+ * in the case a user passes undefined instead of simply omitting the key.
+ *
+ * @param passedObject {T} - The object with the undefined properties.
+ *
+ * @returns {T} - The same options, but with all undefined fields omitted.
+ *
+ * @private
+ */
+export const omitUndefinedProperties = <T extends { [key: string]: any }>(
+	passedOptions: T,
+): T => {
+	// TSC forces the `as T` instead of `const omittedOptions: T = {}`.
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	const omittedOptions = {} as T
+
+	for (const k of Object.keys(passedOptions)) {
+		const key = k as keyof T
+
+		if (passedOptions[key] !== undefined) {
+			omittedOptions[key] = passedOptions[key]
+		}
+	}
+
+	return omittedOptions
+}

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -82,10 +82,11 @@ describe('headers test', () => {
 				windowMs: 2 * 60 * 60 * 1000,
 				limit: 5,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'foo', // Pk param is generated from this
 			}),
 		)
 
-		const policy = '"5-in-2hrs"; q=5; w=7200; pk=:M2U0OGVmOWQyMmUw:'
+		const policy = '"5-in-2hrs"; q=5; w=7200; pk=:MmMyNmI0NmI2OGZm:'
 		const limit = '"5-in-2hrs"; r=4; t=7200'
 
 		await request(app)
@@ -101,17 +102,19 @@ describe('headers test', () => {
 				windowMs: 60 * 1000,
 				limit: 5,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'foo', // Pk param is generated from this
 			}),
 			rateLimit({
 				windowMs: 2 * 24 * 60 * 60 * 1000,
 				limit: 8,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'bar', // Alternate pk
 			}),
 		])
 
 		const policies = [
-			'"5-in-1min"; q=5; w=60; pk=:M2U0OGVmOWQyMmUw:',
-			'"8-in-2days"; q=8; w=172800; pk=:M2U0OGVmOWQyMmUw:',
+			'"5-in-1min"; q=5; w=60; pk=:MmMyNmI0NmI2OGZm:',
+			'"8-in-2days"; q=8; w=172800; pk=:ZmNkZTJiMmVkYmE1:',
 		]
 		const limits = ['"5-in-1min"; r=4; t=60', '"8-in-2days"; r=7; t=172800']
 
@@ -129,6 +132,7 @@ describe('headers test', () => {
 				windowMs: 2 * 60 * 60 * 1000,
 				limit: 5,
 				standardHeaders: 'draft-8',
+				keyGenerator: (request, response) => 'foo', // Pk param is generated from this
 			}),
 		)
 
@@ -136,7 +140,7 @@ describe('headers test', () => {
 			.get('/')
 			.expect(
 				'ratelimit-policy',
-				'"keep-kalm"; q=5; w=7200; pk=:M2U0OGVmOWQyMmUw:',
+				'"keep-kalm"; q=5; w=7200; pk=:MmMyNmI0NmI2OGZm:',
 			)
 			.expect('ratelimit', '"keep-kalm"; r=4; t=7200')
 			.expect(200, 'Hi there!')
@@ -164,6 +168,7 @@ describe('headers test', () => {
 			used: 1,
 			remaining: 4,
 			resetTime: new Date(),
+			key: 'foo',
 		}
 		const windowMs = 60 * 1000
 

--- a/test/library/ip-key-generator-test.ts
+++ b/test/library/ip-key-generator-test.ts
@@ -1,0 +1,36 @@
+import { ipKeyGenerator } from '../../source/index.js'
+
+describe('ipKeyGenerator', () => {
+	it('should return an IPv4 address unchanged', () => {
+		expect(ipKeyGenerator('1.2.3.4')).toBe('1.2.3.4')
+		expect(ipKeyGenerator('1.2.3.4', 16)).toBe('1.2.3.4')
+	})
+
+	it('should return an IPv6 address unchanged with ipv6Subnet set to false', () => {
+		expect(
+			ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', false),
+		).toBe('0123:4567:89ab:cdef:0123:4567:89ab:cdef')
+	})
+
+	it('should apply a default /56 netmask to an IPv6 address', () => {
+		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef')).toBe(
+			'123:4567:89ab:cd00::/56',
+		)
+	})
+
+	it('should apply a /63 netmask to an IPv6 address', () => {
+		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', 63)).toBe(
+			'123:4567:89ab:cdee::/63',
+		)
+	})
+
+	it('should accept abbreviated IPv6 addresses', () => {
+		expect(ipKeyGenerator('123:ABC::89')).toBe('123:abc::/56')
+	})
+
+	it('should return an IPv6 address normalized but otherwise unchanged with a /128 netmask', () => {
+		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', 128)).toBe(
+			'123:4567:89ab:cdef:123:4567:89ab:cdef/128',
+		)
+	})
+})

--- a/test/library/ip-key-generator-test.ts
+++ b/test/library/ip-key-generator-test.ts
@@ -12,9 +12,9 @@ describe('ipKeyGenerator', () => {
 		).toBe('0123:4567:89ab:cdef:0123:4567:89ab:cdef')
 	})
 
-	it('should apply a default /56 netmask to an IPv6 address', () => {
+	it('should apply a default /64 netmask to an IPv6 address (prior to 8.x)', () => {
 		expect(ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef')).toBe(
-			'123:4567:89ab:cd00::/56',
+			'123:4567:89ab:cdef::/64',
 		)
 	})
 
@@ -25,7 +25,7 @@ describe('ipKeyGenerator', () => {
 	})
 
 	it('should accept abbreviated IPv6 addresses', () => {
-		expect(ipKeyGenerator('123:ABC::89')).toBe('123:abc::/56')
+		expect(ipKeyGenerator('123:ABC::89', 56)).toBe('123:abc::/56')
 	})
 
 	it('should return an IPv6 address normalized but otherwise unchanged with a /128 netmask', () => {

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -13,7 +13,7 @@ import express from 'express'
 import supertest from 'supertest'
 import { getValidations } from '../../source/validations.js'
 import type { Store } from '../../source/types'
-import { MemoryStore } from '../../source/index.js'
+import { MemoryStore, ipKeyGenerator } from '../../source/index.js'
 
 describe('validations tests', () => {
 	let validations = getValidations(true)
@@ -43,7 +43,7 @@ describe('validations tests', () => {
 			expect(console.error).toBeCalled()
 		})
 
-		it('shoud log an error for an undefined IP', () => {
+		it('should log an error for an undefined IP', () => {
 			validations.ip(undefined)
 			expect(console.error).toBeCalled()
 		})
@@ -411,6 +411,145 @@ describe('validations tests', () => {
 			validations.creationStack(store)
 			expect(console.error).not.toBeCalled()
 			expect(console.warn).not.toBeCalled()
+		})
+	})
+
+	describe('ipv6Subnet', () => {
+		it('should allow numbers in the 32-64 range', () => {
+			for (let i = 32; i <= 64; i++) {
+				validations.ipv6Subnet(i)
+			}
+
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should allow false', () => {
+			validations.ipv6Subnet(false)
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should error on numbers below 32', () => {
+			validations.ipv6Subnet(31)
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_IPV6_SUBNET' }),
+			)
+		})
+
+		it('should error on numbers above 64', () => {
+			validations.ipv6Subnet(65)
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_IPV6_SUBNET' }),
+			)
+		})
+
+		it('should error on non-integer numbers', () => {
+			validations.ipv6Subnet(48.5)
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_IPV6_SUBNET' }),
+			)
+		})
+
+		it('should error on undefined (return value from configured function)', () => {
+			validations.ipv6Subnet(undefined)
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_IPV6_SUBNET' }),
+			)
+		})
+	})
+
+	describe('ipv6SubnetOrKeyGenerator', () => {
+		it('should allow one or the other (or none)', () => {
+			validations.ipv6SubnetOrKeyGenerator({})
+			validations.ipv6SubnetOrKeyGenerator({ ipv6Subnet: 64 })
+			validations.ipv6SubnetOrKeyGenerator({
+				keyGenerator: (request, response) => 'global',
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should warn on both', () => {
+			validations.ipv6SubnetOrKeyGenerator({
+				ipv6Subnet: 64,
+				keyGenerator: (request, response) => 'global',
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_IPV6SUBNET_OR_KEYGENERATOR' }),
+			)
+		})
+
+		it('should warn on both when ipv6Subnet is false', () => {
+			validations.ipv6SubnetOrKeyGenerator({
+				ipv6Subnet: false,
+				keyGenerator: (request, response) => 'global',
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_IPV6SUBNET_OR_KEYGENERATOR' }),
+			)
+		})
+	})
+
+	describe('keyGeneratorIpFallback', () => {
+		it('should skip on undefined keyGenerator', () => {
+			validations.keyGeneratorIpFallback(undefined)
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should not warn on a keyGenerator that does not use req.ip or request.ip', () => {
+			validations.keyGeneratorIpFallback(function (
+				request: any,
+				response: any,
+			): string {
+				return request.params.apikey as string
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should warn on a keyGenerator that uses req.ip', () => {
+			validations.keyGeneratorIpFallback(function (
+				request: any,
+				response: any,
+			): string {
+				return (request.params.apikey || request.ip) as string
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_KEY_GEN_IPV6' }),
+			)
+		})
+
+		it('should warn on a keyGenerator that uses request.ip', () => {
+			validations.keyGeneratorIpFallback(function (
+				request: any,
+				response: any,
+			) {
+				return (request.params.apikey || request.ip) as string
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_KEY_GEN_IPV6' }),
+			)
+		})
+
+		it('should not warn on a keyGenerator that uses request.ip and ipKeyGenerator', () => {
+			validations.keyGeneratorIpFallback(function (
+				request: any,
+				response: any,
+			): string {
+				return (request.params.apikey as string) || ipKeyGenerator(request.ip)
+			})
+			expect(console.warn).not.toBeCalled()
+			expect(console.error).not.toBeCalled()
 		})
 	})
 })


### PR DESCRIPTION
I branched off of 7.5.1 to make the 7.x branch, then branched off of that to make this one. I cherry-picked the changes, and then changed the default to /64.

Todo:
* [ ] set up CI to correctly handle publishing of backports (or just do it manually?)
  * It needs to be something like `npm publis --tag backports` to ensure it doesn't get treated as the latest release - https://docs.npmjs.com/cli/v8/commands/npm-publish?v=true#tag
* [ ] Update docs (in `main` branch, not this one)
* [ ] Do we want to add in a ChangeWarning for this? I'm leaning towards no.

Once we're happy with this one, we can do the same thing for 6.x