### PR TITLE
Don't return response.send from RequestHandler

### DIFF
--- a/docs/guides/troubleshooting-proxy-issues.mdx
+++ b/docs/guides/troubleshooting-proxy-issues.mdx
@@ -29,7 +29,9 @@ To solve this issue, please follow the steps given below.
     	create a test endpoint that returns the client IP:
 
     	```ts
-    	app.get('/ip', (request, response) => response.send(request.ip))
+        app.get('/ip', (request, response) => {
+          response.send(request.ip);
+        });
     	```
 
     	Make a `get` request to `/ip` and check the IP address returned in the

--- a/docs/guides/troubleshooting-proxy-issues.mdx
+++ b/docs/guides/troubleshooting-proxy-issues.mdx
@@ -29,9 +29,9 @@ To solve this issue, please follow the steps given below.
     	create a test endpoint that returns the client IP:
 
     	```ts
-        app.get('/ip', (request, response) => {
-          response.send(request.ip);
-        });
+    	app.get('/ip', (request, response) => {
+    		response.send(request.ip);
+    	});
     	```
 
     	Make a `get` request to `/ip` and check the IP address returned in the


### PR DESCRIPTION
When pasted into a real app (Express v5), this example would produce a TypeScript error. So I wrapped response.send(…) thing in {} to fix it.