### PR TITLE
fix: export ipKeyGenerator in cjs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"scripts": {
 		"clean": "del-cli dist/ coverage/ *.log *.tmp *.bak *.tgz",
-		"build:cjs": "esbuild --packages=external --platform=node --bundle --target=es2022 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = rateLimit; module.exports.default = rateLimit; module.exports.rateLimit = rateLimit; module.exports.MemoryStore = MemoryStore;\" source/index.ts",
+		"build:cjs": "esbuild --packages=external --platform=node --bundle --target=es2022 --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = Object.assign(rateLimit, module.exports);\" source/index.ts",
 		"build:esm": "esbuild --packages=external --platform=node --bundle --target=es2022 --format=esm --outfile=dist/index.mjs source/index.ts",
 		"build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts dist/index.d.mts",
 		"compile": "run-s clean build:*",


### PR DESCRIPTION
We add a footer to the cjs that redefines the exports in order to keep the original import style\[1\] working, but it had been hard-coded to specific fields rather than just re-exporting everything. Now it re-exports everything, so we shouldn't need to worry about it again if we add more exports in the future.

Fixes #529


\[1\]: 
```js
var rateLimit = require("express-rate-limit");
//...
app.use(rateLimit({ /*...*/ });
```

(For some annoying reason, every TS transpire seems to break this and only exports an object with a `default` field, instead of making the default export the actual thing.)