### PR TITLE
fix: replace vulnerable ip library with ip-address lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
 		"pre-commit": "lint-staged",
 		"prepare": "run-s compile && husky"
 	},
-	"dependencies": {
-		"ip": "2.0.1"
-	},
 	"peerDependencies": {
 		"express": ">= 4.11"
 	},
@@ -85,7 +82,6 @@
 		"@express-rate-limit/tsconfig": "1.0.2",
 		"@jest/globals": "30.0.4",
 		"@types/express": "5.0.3",
-		"@types/ip": "1.1.3",
 		"@types/jest": "30.0.0",
 		"@types/node": "24.0.14",
 		"@types/supertest": "6.0.3",
@@ -109,5 +105,8 @@
 	"lint-staged": {
 		"*.{js,ts,json}": "biome check --write",
 		"*.{md,yaml}": "prettier --write"
+	},
+	"dependencies": {
+		"ip-address": "10.0.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ settings:
 importers:
   .:
     dependencies:
-      ip:
-        specifier: 2.0.1
-        version: 2.0.1
+      ip-address:
+        specifier: 10.0.1
+        version: 10.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.1.1
@@ -26,9 +26,6 @@ importers:
       '@types/express':
         specifier: 5.0.3
         version: 5.0.3
-      '@types/ip':
-        specifier: 1.1.3
-        version: 1.1.3
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -1872,12 +1869,6 @@ packages:
     resolution:
       {
         integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==,
-      }
-
-  '@types/ip@1.1.3':
-    resolution:
-      {
-        integrity: sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==,
       }
 
   '@types/istanbul-lib-coverage@2.0.6':
@@ -4517,6 +4508,13 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  ip-address@10.0.1:
+    resolution:
+      {
+        integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==,
+      }
+    engines: { node: '>= 12' }
+
   ip-address@9.0.5:
     resolution:
       {
@@ -4530,12 +4528,6 @@ packages:
         integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==,
       }
     engines: { node: '>=8' }
-
-  ip@2.0.1:
-    resolution:
-      {
-        integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==,
-      }
 
   ipaddr.js@1.9.1:
     resolution:
@@ -9722,10 +9714,6 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/ip@1.1.3':
-    dependencies:
-      '@types/node': 24.0.14
-
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -11499,14 +11487,14 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  ip-address@10.0.1: {}
+
   ip-address@9.0.5:
     dependencies:
       jsbn: 1.1.0
       sprintf-js: 1.1.3
 
   ip-regex@4.3.0: {}
-
-  ip@2.0.1: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/source/ip-key-generator.ts
+++ b/source/ip-key-generator.ts
@@ -1,5 +1,5 @@
 import { isIPv6 } from 'node:net'
-import iptools from 'ip'
+import { Address6 } from 'ip-address'
 
 /**
  * Returns the IP address itself for IPv4, or a CIDR-notation subnet for IPv6.
@@ -19,10 +19,7 @@ import iptools from 'ip'
 export function ipKeyGenerator(ip: string, ipv6Subnet: number | false = 56) {
 	if (ipv6Subnet && isIPv6(ip)) {
 		// For IPv6, return the network address of the subnet in CIDR format
-		return `${iptools.mask(
-			ip,
-			iptools.fromPrefixLen(ipv6Subnet),
-		)}/${ipv6Subnet}`
+		return `${new Address6(`${ip}/${ipv6Subnet}`).startAddress().correctForm()}/${ipv6Subnet}`
 	}
 
 	// For IPv4, just return the IP address itself


### PR DESCRIPTION
I can't recall if this was one of the libraries I initially looked at, but I decided to give it a shot today, as an alternate to #535 

The double-string-concatenation here seems a little dumb, but it does seem to work reliably and might be less bad than a bunch of ai-generated code.

Fixes #533
Closes #535