### PR TITLE
test: check for Request renamed to Request$1 in types

### DIFF
--- a/test/library/types-test.ts
+++ b/test/library/types-test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from '@jest/globals'
+
+describe('types tests', () => {
+	// apparently jest compiles this to cjs and dosn't fixup import.meta.dirname, so just use __dirname global here
+	const TYPES_PATH = path.join(__dirname, '../../dist/index.d.ts')
+	const TYPES_EXIST = fs.existsSync(TYPES_PATH)
+	const IS_CI = !!process.env.CI
+
+	// automatically skip the test if running locally and the types don't exist
+	// always run in CI so that it will fail if the types location changes
+	const maybeTest = TYPES_EXIST || IS_CI ? it : it.skip
+
+	// see https://github.com/express-rate-limit/express-rate-limit/issues/530
+	// note: this is a very dumb test and should probably be replaced by something that tries to *use* the types
+	maybeTest(
+		'should not have Request renamed to Request$1 in the types',
+		async () => {
+			const source = fs.readFileSync(TYPES_PATH).toString()
+			expect(source).toEqual(expect.not.stringContaining('Request$1'))
+		},
+	)
+})


### PR DESCRIPTION
This is an incredibly dumb test, but I couldn't come up with anything smarter that actually worked. I tried a couple of different ways to import and use the types in the test, and I also tried a couple of different type linting sort of tools. It all either failed in unexpected ways, or passed even when the types were broken.

This test passes with dts-bundle-generator 8.1.2 generating the types and (correctly) fails with dts-bundle-generator 9.5.1

Relates to:
* https://github.com/express-rate-limit/express-rate-limit/issues/530
* https://github.com/express-rate-limit/express-rate-limit/pull/534
* https://github.com/express-rate-limit/express-rate-limit/pull/537#issuecomment-3099816379
* https://github.com/timocov/dts-bundle-generator/issues/353