### PR TITLE
Add validation check for Forwarded header

### DIFF
--- a/docs/guides/troubleshooting-proxy-issues.mdx
+++ b/docs/guides/troubleshooting-proxy-issues.mdx
@@ -12,7 +12,8 @@ request might be the IP of the load balancer/reverse proxy (making the rate
 limiter effectively a global one and blocking all requests once the limit is
 reached) or `undefined`.
 
-To solve this issue, please follow the steps given below.
+To solve this issue, assuming the proxy (or proxies) set the `X-Forwarded-For`
+header, please follow the steps given below.
 
 <Steps>
 
@@ -46,6 +47,14 @@ To solve this issue, please follow the steps given below.
 
 For more information about the `trust proxy` setting, take a look at the
 [official Express documentation](https://expressjs.com/en/guide/behind-proxies.html).
+
+#### Forwarded header
+
+If the server instead sets the `Forwarded` header, the steps are similar except
+that you'll need a
+[custom keyGenerator](/reference/error-codes#err-erl-forwarded-header) because
+express does not have built-in support for the `Forwarded` header (as of version
+5.1.0),
 
 ### Port Numbers in IP Addresses
 

--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.1.0)
+
+### Fixed
+
+- `RateLimit-Reset` is now always set when `standardHeaders` is set to
+  `'draft-6'` and the store supports it.
+
+### Added
+
+- New `windowMs` validation check that ensures it's in the valid range when
+  using the built-in Memory store.
+- New `forwardedHeader` validation check to warn when the `Forwarded` header is
+  present but ignored.
+
 ## [8.0.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.0.1)
 
 ### Fixed

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -508,6 +508,7 @@ Supported validations are:
 - [ip](/reference/error-codes#err-erl-undefined-ip-address)
 - [trustProxy](/reference/error-codes#err-erl-permissive-trust-proxy)
 - [xForwardedForHeader](/reference/error-codes#err-erl-unexpected-x-forwarded-for)
+- [forwardedHeader](/reference/error-codes#err-erl-forwarded-header)
 - [positiveHits](/reference/error-codes#err-erl-invalid-hits)
 - [unsharedStore](/reference/error-codes#err-erl-store-reuse)
 - [singleCount](/reference/error-codes#err-erl-double-count)

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -447,12 +447,12 @@ check.
 
 Node.js (as of version 24.6.0)
 [limits `setInterval()` delays to the max 32-bit signed integer value of `2147483647` milliseconds](https://nodejs.org/api/timers.html#setintervalcallback-delay-args),
-which is about 28.4 days. Accordingly, express-rate-limit checks the value
+which is about 28.4 days. Accordingly, express-rate-limit checks the `windowMs` value
 before using it in the default MemoryStore and warns when it's out of range.
 
 Longer values can be used with most external [stores](/reference/stores).
 
-Set `validate: {limit: false}` in the options to disable the check.
+Set `validate: {windowMs: false}` in the options to disable the check.
 
 ## Warnings
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -123,20 +123,20 @@ import { rateLimit, ipKeyGenerator } from 'express-rate-limit'
 
 // ...
 
+const NUMBER_OF_PROXIES_TO_TRUST = 1
+
 app.use(
 	rateLimit({
 		keyGenerator: (req, res) => {
 			let ip = req.ip
-			if (req.headers.forwarded) {
-				try {
-					ip = parseForwarded(req.headers.forwarded).pop().for
-				} catch (ex) {
-					console.error(
-						'Error parsing Forwarded header:',
-						req.headers.forwarded,
-						ex,
-					)
-				}
+			try {
+				const forwards = parseForwarded(req.headers.forwarded)
+				ip = forwards[forwards.length - NUMBER_OF_PROXIES_TO_TRUST].for
+			} catch (ex) {
+				console.error(
+					`Error parsing Forwarded header ${req.headers.forwarded} from ${req.ip}:`,
+					ex,
+				)
 			}
 			return ipKeyGenerator(ip)
 		},
@@ -147,6 +147,12 @@ app.use(
 
 (`ipKeyGenerator` is needed for proper limiting of IPv6 users, see
 [ERR_ERL_KEY_GEN_IPV6](#err-erl-ipv6subnet-or-keygenerator) for more info.)
+
+If there are multiple proxies between your server and the internet and each adds
+a `Forwarded` header, increment `NUMBER_OF_PROXIES_TO_TRUST` to match.
+
+See [Troubleshooting Proxy Issues](/guides/troubleshooting-proxy-issues) for
+additional information.
 
 Set `validate: {forwardedHeader: false}` in the options to disable the check.
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -447,8 +447,9 @@ check.
 
 Node.js (as of version 24.6.0)
 [limits `setInterval()` delays to the max 32-bit signed integer value of `2147483647` milliseconds](https://nodejs.org/api/timers.html#setintervalcallback-delay-args),
-which is about 28.4 days. Accordingly, express-rate-limit checks the `windowMs` value
-before using it in the default MemoryStore and warns when it's out of range.
+which is about 28.4 days. Accordingly, express-rate-limit checks the `windowMs`
+value before using it in the default MemoryStore and warns when it's out of
+range.
 
 Longer values can be used with most external [stores](/reference/stores).
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -154,6 +154,10 @@ a `Forwarded` header, increment `NUMBER_OF_PROXIES_TO_TRUST` to match.
 See [Troubleshooting Proxy Issues](/guides/troubleshooting-proxy-issues) for
 additional information.
 
+`req.ip` could also be set before express-rate-limit processes the request. If
+it is set to anything other than the default value (`req.socket.remoteAddress`),
+this error will be automatically suppressed.
+
 Set `validate: {forwardedHeader: false}` in the options to disable the check.
 
 ### `ERR_ERL_INVALID_HITS`

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -96,6 +96,60 @@ This check will be prevented if a custom `keyGenerator` is supplied.
 Set `validate: {xForwardedForHeader: false}` in the options to disable the
 check.
 
+### `ERR_ERL_FORWARDED_HEADER`
+
+> Added in `8.1.0`.
+
+This error is logged when the `Forwarded` header
+([RFC 7239](https://tools.ietf.org/html/rfc7239)) is set (indicating use of a
+proxy) and the default [`keyGenerator`] is used.
+
+As of express@5.1.0, express's `trust proxy` setting does not support the
+`Forwarded` header, only `X-Forwarded-For`, and express-rate-limit relies on
+express to determine the requester's IP address, so this header is ignored in
+the default configuration.
+
+(There is an
+[open ticket requesting support be added to the proxy-addr library](https://github.com/jshttp/proxy-addr/issues/20)
+that express uses to determine IP address.)
+
+To use this header, add a custom [keyGenerator] that parses it and returns the
+correct IP. For example, using the
+[forwarded-parse](https://www.npmjs.com/package/forwarded-parse) library:
+
+```js
+import parseForwarded from 'forwarded-parse'
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit'
+
+// ...
+
+app.use(
+	rateLimit({
+		keyGenerator: (req, res) => {
+			let ip = req.ip
+			if (req.headers.forwarded) {
+				try {
+					ip = parseForwarded(req.headers.forwarded).pop().for
+				} catch (ex) {
+					console.error(
+						'Error parsing Forwarded header:',
+						req.headers.forwarded,
+						ex,
+					)
+				}
+			}
+			return ipKeyGenerator(ip)
+		},
+		// ...
+	}),
+)
+```
+
+(`ipKeyGenerator` is needed for proper limiting of IPv6 users, see
+[ERR_ERL_KEY_GEN_IPV6](#err-erl-ipv6subnet-or-keygenerator) for more info.)
+
+Set `validate: {forwardedHeader: false}` in the options to disable the check.
+
 ### `ERR_ERL_INVALID_HITS`
 
 > Added in `6.10.0`.
@@ -443,3 +497,6 @@ option to replicate its behaviour, or use the recommended
 `standardHeaders: 'draft-7'` option instead.
 
 Set `validate: {draftPolliHeaders: false}` in the options to disable the check.
+
+[`keyGenerator`]: /reference/configuration#keygenerator
+[keyGenerator]: /reference/configuration#keygenerator

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -227,6 +227,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 			validations.ip(request.ip)
 			validations.trustProxy(request)
 			validations.xForwardedForHeader(request)
+			validations.forwardedHeader(request)
 
 			// Note: eslint thinks the ! is unnecessary but dts-bundle-generator disagrees
 			// biome-ignore lint/style/noNonNullAssertion: validations.ip is called above

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -139,6 +139,22 @@ const validations = {
 	},
 
 	/**
+	 * Alert the user if the Forwarded header is set (standardized version of X-Forwarded-For - not supported by express as of version 5.1.0)
+	 *
+	 * @param request {Request} - The Express request object.
+	 *
+	 * @returns {void}
+	 */
+	forwardedHeader(request: Request) {
+		if (request.headers['forwarded']) {
+			throw new ValidationError(
+				'ERR_ERL_FORWARDED_HEADER',
+				`The 'Forwarded' header (standardized X-Forwarded-For) is set but currently being ignored. Add a custom keyGenerator to use a value from this header.`,
+			)
+		}
+	},
+
+	/**
 	 * Ensures totalHits value from store is a positive integer.
 	 *
 	 * @param hits {any} - The `totalHits` returned by the store.

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -146,7 +146,11 @@ const validations = {
 	 * @returns {void}
 	 */
 	forwardedHeader(request: Request) {
-		if (request.headers['forwarded']) {
+		if (
+			request.headers.forwarded &&
+			request.ip === request.socket?.remoteAddress
+		) {
+			// if req.ip is set to something else, assume it's correct and don't warn here
 			throw new ValidationError(
 				'ERR_ERL_FORWARDED_HEADER',
 				`The 'Forwarded' header (standardized X-Forwarded-For) is set but currently being ignored. Add a custom keyGenerator to use a value from this header.`,

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -102,15 +102,35 @@ describe('validations tests', () => {
 		it('should log an error when the Forwarded set to any value, but not when it is unset', () => {
 			validations.forwardedHeader({
 				headers: {},
+				ip: '1.2.3.4',
+				socket: { remoteAddress: '1.2.3.4' },
 			} as any)
 			expect(console.error).not.toHaveBeenCalled()
 
 			validations.forwardedHeader({
-				headers: { forwarded: '1.2.3.4' },
+				headers: { forwarded: '5.6.7.8' },
+				ip: '1.2.3.4',
+				socket: { remoteAddress: '1.2.3.4' },
 			} as any)
 			expect(console.error).toHaveBeenCalledWith(
 				expect.objectContaining({ code: 'ERR_ERL_FORWARDED_HEADER' }),
 			)
+		})
+
+		it('should not log an error when request.ip has been set to a non-default value', () => {
+			validations.forwardedHeader({
+				headers: {},
+				ip: '1.2.3.100',
+				socket: { remoteAddress: '1.2.3.4' },
+			} as any)
+			expect(console.error).not.toHaveBeenCalled()
+
+			validations.forwardedHeader({
+				headers: { forwarded: '5.6.7.8' },
+				ip: '1.2.3.100',
+				socket: { remoteAddress: '1.2.3.4' },
+			} as any)
+			expect(console.error).not.toHaveBeenCalled()
 		})
 	})
 

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -108,7 +108,9 @@ describe('validations tests', () => {
 			validations.forwardedHeader({
 				headers: { forwarded: '1.2.3.4' },
 			} as any)
-			expect(console.error).toHaveBeenCalled()
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_FORWARDED_HEADER' }),
+			)
 		})
 	})
 

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -98,6 +98,20 @@ describe('validations tests', () => {
 		})
 	})
 
+	describe('forwardedHeader', () => {
+		it('should log an error when the Forwarded set to any value, but not when it is unset', () => {
+			validations.forwardedHeader({
+				headers: {},
+			} as any)
+			expect(console.error).not.toHaveBeenCalled()
+
+			validations.forwardedHeader({
+				headers: { forwarded: '1.2.3.4' },
+			} as any)
+			expect(console.error).toHaveBeenCalled()
+		})
+	})
+
 	describe('positiveHits', () => {
 		it('should log an error if hits is non-numeric', () => {
 			validations.positiveHits(true)


### PR DESCRIPTION
This alerts the user if a `Forwarded` header (standardized version of `X-Forwarded-For` & friends) is set when using the default `keyGenerator`, similar to our check for `X-Forwarded-For` when `trust proxy` is not enabled.

I also added an example to the docs with a custom `keyGenerator` that uses the [forwarded-parse](https://www.npmjs.com/package/forwarded-parse) library to parse and use the rightmost forwarded header (e.g. the last one, from the nearest proxy server).

This doesn't quite fix https://github.com/express-rate-limit/express-rate-limit/issues/488 but it definitely improves the situation. 

I'm hoping that support will eventually be added to express, e.g. via [proxy-addr](https://github.com/jshttp/proxy-addr/issues/20). If it doesn't, I may consider adding built-in support to express-rate-limit. But for now, at least, we have a warning and an example.