### PR TITLE
Document windowMs limit for MemoryStore and warn on invalid values

### DIFF
--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -25,11 +25,18 @@ create multiple rate limiters.
 <Note>
 
 For stores that do not implement the `init` function (including all legacy
-stores - see the [data stores page](/reference/stores)), you may need to
-configure this value twice, once here and once on the store. In some cases the
-units also differ (e.g. seconds vs milliseconds).
+stores - see the [data stores page][stores]), you may need to configure this
+value twice, once here and once on the store. In some cases the units also
+differ (e.g. seconds vs milliseconds).
 
 </Note>
+
+Maximum value with the default MemoryStore is `2147483647` (2^31-1, ~28.4 days)
+due to
+[limitations of the `setInterval()` call in node.js](https://nodejs.org/api/timers.html#setintervalcallback-delay-args).
+(Also, all rate limits in the default MemoryStore are reset when the node.js
+process is restarted.) Most other [stores] support larger values and retain
+their state when node.js is reset.
 
 Defaults to `60000` ms (= 1 minute).
 
@@ -514,5 +521,8 @@ Supported validations are:
 - [ipv6Subnet](/reference/error-codes#err-erl-ipv6-subnet)
 - [ipv6SubnetOrKeyGenerator](/reference/error-codes#err-erl-ipv6subnet-or-keygenerator)
 - [keyGeneratorIpFallback](/reference/error-codes#err-erl-key-gen-ipv6)
+- [windowMs](/reference/error-codes#err-erl-window-ms)
 
 Defaults to `true`.
+
+[stores]: /reference/stores

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -377,6 +377,19 @@ account.
 Set `validate: {keyGeneratorIpFallback: false}` in the options to disable the
 check.
 
+### `ERR_ERL_WINDOW_MS`
+
+> Added in `8.1.0`
+
+Node.js (as of version 24.6.0)
+[limits `setInterval()` delays to the max 32-bit signed integer value of `2147483647` milliseconds](https://nodejs.org/api/timers.html#setintervalcallback-delay-args),
+which is about 28.4 days. Accordingly, express-rate-limit checks the value
+before using it in the default MemoryStore and warns when it's out of range.
+
+Longer values can be used with most external [stores](/reference/stores).
+
+Set `validate: {limit: false}` in the options to disable the check.
+
 ## Warnings
 
 ### `WRN_ERL_MAX_ZERO`

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -2,6 +2,7 @@
 // A memory store for hit counts
 
 import type { ClientRateLimitInfo, Options, Store } from './types.js'
+import type { Validations } from './validations.js'
 
 /**
  * The record that stores information about a client - namely, how many times
@@ -49,6 +50,8 @@ export class MemoryStore implements Store {
 	 */
 	localKeys = true
 
+	constructor(private validations?: Validations) {}
+
 	/**
 	 * Method that initializes the store.
 	 *
@@ -57,6 +60,9 @@ export class MemoryStore implements Store {
 	init(options: Options): void {
 		// Get the duration of a window from the options.
 		this.windowMs = options.windowMs
+
+		// check for a valid value
+		this.validations?.windowMs(this.windowMs)
 
 		// Indicates that init was called more than once.
 		// Could happen if a store was shared between multiple instances.

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -275,7 +275,9 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 		standardHeaders,
 		// Note that this field is declared after the user's options are spread in,
 		// so that this field doesn't get overridden with an un-promisified store!
-		store: promisifyStore(notUndefinedOptions.store ?? new MemoryStore()),
+		store: promisifyStore(
+			notUndefinedOptions.store ?? new MemoryStore(validations),
+		),
 		// Print an error to the console if a few known misconfigurations are detected.
 		validations,
 	}

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -391,6 +391,12 @@ const validations = {
 		}
 	},
 
+	/**
+	 * Checks to see if the window duration is greater than 2^32 - 1. This is only
+	 * called by the default MemoryStore, since it uses Node's setInterval method.
+	 *
+	 * See https://nodejs.org/api/timers.html#setintervalcallback-delay-args.
+	 */
 	windowMs(windowMs: number) {
 		const SET_TIMEOUT_MAX = 2 ** 31 - 1
 		if (

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -390,6 +390,21 @@ const validations = {
 			)
 		}
 	},
+
+	windowMs(windowMs: number) {
+		const SET_TIMEOUT_MAX = 2 ** 31 - 1
+		if (
+			typeof windowMs !== 'number' ||
+			Number.isNaN(windowMs) ||
+			windowMs < 1 ||
+			windowMs > SET_TIMEOUT_MAX
+		) {
+			throw new ValidationError(
+				'ERR_ERL_WINDOW_MS',
+				`Invalid windowMs value: ${windowMs}${typeof windowMs !== 'number' ? ` (${typeof windowMs})` : ''}, must be a number between 1 and ${SET_TIMEOUT_MAX} when using the default MemoryStore`,
+			)
+		}
+	},
 }
 
 export type Validations = typeof validations

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -558,4 +558,17 @@ describe('validations tests', () => {
 			expect(console.error).not.toHaveBeenCalled()
 		})
 	})
+
+	describe('windowMs', () => {
+		it('should warn on large values, but not in-range values', () => {
+			validations.windowMs(5 * 60 * 1000)
+			expect(console.warn).not.toHaveBeenCalled()
+			expect(console.error).not.toHaveBeenCalled()
+
+			validations.windowMs(30 * 24 * 60 * 60 * 1000)
+			expect(console.error).toHaveBeenCalledWith(
+				expect.objectContaining({ code: 'ERR_ERL_WINDOW_MS' }),
+			)
+		})
+	})
 })


### PR DESCRIPTION
This is mainly to catch values over node.js's maximum (~28.4 days), but it will also catch other invalid values such as negative numbers and NaN.

Fixes #546 (Sort of. It at least clarifies things - it's about as much of a fix as we're going to do.)