### PR TITLE
fix: include RateLimit-Reset header when resetSeconds is 0

### DIFF
--- a/source/headers.ts
+++ b/source/headers.ts
@@ -98,7 +98,7 @@ export const setDraft6Headers = (
 	response.setHeader('RateLimit-Remaining', info.remaining.toString())
 
 	// Set this header only if the store returns a `resetTime`.
-	if (resetSeconds)
+	if (typeof resetSeconds === 'number')
 		response.setHeader('RateLimit-Reset', resetSeconds.toString())
 }
 


### PR DESCRIPTION
Previously, the RateLimit-Reset header was incorrectly omitted when resetSeconds was 0 due to a falsy check. This occurred when the rate limit window had just expired (resetTime <= current time), causing Math.max(0, deltaSeconds) to return 0.

Changed the condition from `if (resetSeconds)` to
`if (typeof resetSeconds === 'number')` to ensure the header is included for all numeric values, including 0.

Fix #552 